### PR TITLE
Enable PDF support on Google Cloud

### DIFF
--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -15,16 +15,19 @@ if ($settings['google_projectid']) {
 }
 // The GAE environment requires a single entry point, so we're
 // doing basic routing from here
-switch (@parse_url($_SERVER['REQUEST_URI'])['path']) {
+$parsedUrl = @parse_url($_SERVER['REQUEST_URI'])['path'];
+switch ($parsedUrl) {
 case '/':
 case '/index.php':
     require 'index.php';
     break;
 case '/login.php':
-    require 'login.php';
-    break;
 case '/ajax.php':
-    require 'ajax.php';
+case '/pdf/workshopcard.php':
+case '/pdf/bicyclecard.php':
+case '/pdf/qr.php':
+case '/pdf/dryfood.php':
+    require substr($parsedUrl,1); // trim /
     break;
 default:
     http_response_code(404);

--- a/library/core.php
+++ b/library/core.php
@@ -6,7 +6,7 @@ session_name('core');
 session_start();
 
 # load configuration file
-require_once('config.php');
+require_once(__DIR__.'/../config.php');
 
 # load database library
 require_once('lib/database.php');

--- a/pdf/bicyclecard.php
+++ b/pdf/bicyclecard.php
@@ -1,5 +1,5 @@
 <?php
-require('../library/core.php');
+require(__DIR__.'/../library/core.php');
 
 ini_set('display_errors',1);
 error_reporting(E_ALL);

--- a/pdf/dryfood.php
+++ b/pdf/dryfood.php
@@ -1,5 +1,5 @@
 <?php
-require('../library/core.php');
+require(__DIR__.'/../library/core.php');
 
 ini_set('display_errors',1);
 error_reporting(E_ALL);

--- a/pdf/qr.php
+++ b/pdf/qr.php
@@ -1,5 +1,5 @@
 <?php
-require('../library/core.php');
+require(__DIR__.'/../library/core.php');
 
 ini_set('display_errors',1);
 error_reporting(E_ALL);

--- a/pdf/workshopcard.php
+++ b/pdf/workshopcard.php
@@ -1,5 +1,5 @@
 <?php
-require('../library/core.php');
+require(__DIR__.'/../library/core.php');
 
 ini_set('display_errors',1);
 error_reporting(E_ALL);


### PR DESCRIPTION
Allow the PDF endpoints to be reached through the google cloud entry point. Had to fix some include paths to make this happen, as the pdf files are now
accessed both directly in /pdf/xyz.php and from the root.