### PR TITLE
Change: move box icon

### DIFF
--- a/include/stock-list_edit.php
+++ b/include/stock-list_edit.php
@@ -81,7 +81,7 @@
 		listsetting('allowselectinvisible',false);
 
 		$locations = db_simplearray('SELECT id, label FROM locations WHERE camp_id = '.$_SESSION['camp']['id'].' ORDER BY seq');
-		addbutton('movebox','Move',array('icon'=>'fa-arrows', 'options'=>$locations));
+		addbutton('movebox','Move',array('icon'=>'fa-truck', 'options'=>$locations));
 		addbutton('order','Order from warehouse',array('icon'=>'fa-shopping-cart'));
 		addbutton('undo-order','Undo order',array('icon'=>'fa-undo'));
 

--- a/include/stock.php
+++ b/include/stock.php
@@ -73,7 +73,7 @@
 		listsetting('add', 'Add');
 
 		$locations = db_simplearray('SELECT id, label FROM locations WHERE camp_id = '.$_SESSION['camp']['id'].' ORDER BY seq');
-		addbutton('movebox','Move',array('icon'=>'fa-arrows', 'options'=>$locations));
+		addbutton('movebox','Move',array('icon'=>'fa-truck', 'options'=>$locations));
 		addbutton('qr','Make label',array('icon'=>'fa-print'));
 		addbutton('order','Order from warehouse',array('icon'=>'fa-shopping-cart'));
 		addbutton('undo-order','Undo order',array('icon'=>'fa-undo'));


### PR DESCRIPTION
**change:** "move box" icons 

Upgrade from FA 4 to 5 seems to be unreasonable [too much work](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4) (it's not backwards compatible!) just to get one of those new boxes icons they offer in v5.