### PR TITLE
Usergroup bases display

### DIFF
--- a/include/cms_usergroups.php
+++ b/include/cms_usergroups.php
@@ -31,20 +31,23 @@
 				'.(!$_SESSION['user']['is_admin']?' AND l.level < '.intval($_SESSION['usergroup']['userlevel']):'').'
 			GROUP BY g.id');
 			
-		$num_camps=db_value('
-		SELECT 
-			COUNT(c.name)
-		FROM cms_usergroups_camps AS x
-		INNER JOIN cms_usergroups AS g ON x.cms_usergroups_id = g.id
-		INNER JOIN cms_users AS us ON (us.cms_usergroups_id = g.id)
-		INNER JOIN camps as c ON c.id = x.camp_id 
-		WHERE us.id = '.$_SESSION['user']['id'].' ');
-		
 
 		addcolumn('text','Name','label');
 		addcolumn('text','Level','userlevel');
-		if ($num_camps>1 OR $_SESSION['user']['is_admin']){
-		addcolumn('text','Bases','camps');}
+
+		$num_camps_user_can_access = db_value('
+			SELECT 
+				COUNT(c.name)
+			FROM cms_usergroups_camps AS x
+			INNER JOIN cms_usergroups AS g ON x.cms_usergroups_id = g.id
+			INNER JOIN cms_users AS us ON (us.cms_usergroups_id = g.id)
+			INNER JOIN camps as c ON c.id = x.camp_id 
+			WHERE us.id = '.$_SESSION['user']['id'].' ');
+			
+		if ($num_camps_user_can_access>1 OR $_SESSION['user']['is_admin'])
+		{
+			addcolumn('text','Bases','camps');
+		}
 		
 		listsetting('allowsort',true);
 		listsetting('add', 'Add a User Group');

--- a/include/cms_usergroups.php
+++ b/include/cms_usergroups.php
@@ -36,7 +36,7 @@
 			COUNT(c.name)
 		FROM cms_usergroups_camps AS x
 		INNER JOIN cms_usergroups AS g ON x.cms_usergroups_id = g.id
-		INNER JOIN cms_users AS us ON (us.cms_usergroups_id = g.id) OR us.id = 1
+		INNER JOIN cms_users AS us ON (us.cms_usergroups_id = g.id)
 		INNER JOIN camps as c ON c.id = x.camp_id 
 		WHERE us.id = '.$_SESSION['user']['id'].' ');
 		

--- a/include/cms_usergroups.php
+++ b/include/cms_usergroups.php
@@ -11,7 +11,7 @@
 
 		$cmsmain->assign('title','User groups');
 		listsetting('search', array('g.label'));
-
+		
 		$data = getlistdata('
 			SELECT g.*, 
 				IF(
@@ -30,11 +30,22 @@
 			WHERE (NOT g.deleted OR g.deleted IS NULL) AND g.organisation_id = '.$_SESSION['organisation']['id'].'
 				'.(!$_SESSION['user']['is_admin']?' AND l.level < '.intval($_SESSION['usergroup']['userlevel']):'').'
 			GROUP BY g.id');
+			
+		$num_camps=db_value('
+		SELECT 
+			COUNT(c.name)
+		FROM cms_usergroups_camps AS x
+		INNER JOIN cms_usergroups AS g ON x.cms_usergroups_id = g.id
+		INNER JOIN cms_users AS us ON (us.cms_usergroups_id = g.id) OR us.id = 1
+		INNER JOIN camps as c ON c.id = x.camp_id 
+		WHERE us.id = '.$_SESSION['user']['id'].' ');
+		
 
 		addcolumn('text','Name','label');
 		addcolumn('text','Level','userlevel');
-		addcolumn('text','Bases','camps');
-
+		if ($num_camps>1 OR $_SESSION['user']['is_admin']){
+		addcolumn('text','Bases','camps');}
+		
 		listsetting('allowsort',true);
 		listsetting('add', 'Add a User Group');
 

--- a/include/cms_usergroups.php
+++ b/include/cms_usergroups.php
@@ -33,7 +33,7 @@
 
 		addcolumn('text','Name','label');
 		addcolumn('text','Level','userlevel');
-		addcolumn('text','Bases','bases');
+		addcolumn('text','Bases','camps');
 
 		listsetting('allowsort',true);
 		listsetting('add', 'Add a User Group');


### PR DESCRIPTION
The base names are visible, and the base column is hidden if the current user has access to less than 2 bases and is not an admin. The admin condition is there to accommodate some_admin, which has no usergroup, I am not sure if there is a backdoor like this in the running implementation, if no, we possibly could remove the condition on admin, since normal users don't see the usergroups menu anyway