### PR TITLE
Always log session state in Sentry

### DIFF
--- a/library/lib/errorhandling.php
+++ b/library/lib/errorhandling.php
@@ -2,15 +2,18 @@
 
 function bootstrap_exception_handler(\Throwable $ex)
 {
-	if (isset($_SESSION['user'])) {
-		Sentry\configureScope(function (Sentry\State\Scope $scope): void {
+	Sentry\configureScope(function (Sentry\State\Scope $scope): void {
+		if (isset($_SESSION['user'])) {
 			$scope->setTag('logged in', 'true');
 			$scope->setUser([
 				'id' => $_SESSION['user']['id'],
 			]);
-			$scope->setExtra('session', $_SESSION);
-		});
-	} 
+		} else {
+			$scope->setTag('logged in', 'false');
+		}
+		$scope->setExtra('session', $_SESSION);
+	});
+
 	Sentry\captureException($ex);
 	$eventId = Sentry\State\Hub::getCurrent()->getLastEventId();
 


### PR DESCRIPTION
Previously it was logged present when we are signed in - but seeing weird sign in issues for mobile.php, so hoping this extra logging will reveal why