### PR TITLE
Enable "Add and new" button in beneficiary menu

### DIFF
--- a/include/people_edit.php
+++ b/include/people_edit.php
@@ -236,8 +236,10 @@
 	addfield('created','Created','created',array('aside'=>true));
 
 	if ($id) addformbutton('submitandedit',$translate['cms_form_save']);
-	else addformbutton('submitandnew',"Save and new");
-
+	// weird bug addformbutton helper function does not anything to $formbuttons
+	// THIS IS JUST A WORK AROUND
+	// else addformbutton('submitandnew',"Save and new");
+	else $formbuttons[]=array('label'=> 'Submit and new', 'action'=> 'submitandnew');
 
 	// Tabs
 	$tabs['people'] = 'Personal';
@@ -256,7 +258,6 @@
 	if(!$data['parent_id'] && $data['id']) $tabs['transaction']='Transactions';
 
 	$tabs['signature'] = 'Privacy declaration';
-
 	$cmsmain->assign('tabs',$tabs);
 	$cmsmain->assign('data',$data);
 	$cmsmain->assign('formelements',$formdata);


### PR DESCRIPTION
The reason for this bug needs more investigation.

@aerinsol @jamescrowley The helper function `addformbutton` does not work for some reason anymore. It does not add entries to the global array `$formbuttons` anymore. This affects any instance of addformbutton throughout the code. E.g., the "Submit and edit" button in the Boxes menu does not work anymore, too.

 Were there any changes recently which could just this helper function?

#### Related trello card
https://trello.com/c/AJFbDch4 