### PR TITLE
Enable remote debugging support for the docker containers

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -3,3 +3,5 @@ FROM php:7.2.2-apache
 RUN a2enmod rewrite
 # PHP extensions
 RUN docker-php-ext-install pdo_mysql exif
+# Enable xdebug for debugging & profiling
+RUN pecl install xdebug && docker-php-ext-enable xdebug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
+            "pathMappings": {
+                "/var/www/html": "${workspaceFolder}"
+            },
+            "xdebugSettings": {
+                "max_data": 65535,
+                "show_hidden": 1,
+                "max_children": 100,
+                "max_depth": 5
+            }
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 9000
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ We're using [Phinx](https://phinx.org/) and [phinx-migrations-generator](https:/
 
 Will generate a new migration based on the diff of /db/migrations/schema.php.
 
+### Debugging
+
+We have enabled XDebug remote debugging in the default Docker configuration, so you
+can step through your code.
+
+If you're using VS Code, if you install the [PHP Debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) extension and start the 'Listen for XDebug' configuration, you can then set breakpoints in your code.
+
 ### Contribution guidelines ###
 
 You gotta be awesome and kind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,11 @@ services:
       - .:/var/www/html/
     ports:
       - "8100:80"
+    environment:
+      # WARNING: you do *not* want these environment variables set
+      # in a production environment, as they enable remote
+      # debugging
+      XDEBUG_CONFIG: remote_host=host.docker.internal remote_port=9000 remote_enable=1 idekey=IDEA_DEBUG profiler_enable=1 profiler_output_dir=/tmp/xdebug-profiler
     stdin_open: true
     tty: true
+


### PR DESCRIPTION
While trying to profile to diagnose performance issues, I needed to enable Xdebug to get the profiling information out. It also enables line-by-line step through/debugging/breakpoints so pushing here as may be helpful to diagnose future issues.

Enable remote debugging support for the docker containers  …
* The dockerfile was updated to include the xdebug extension, and be automatically enabled in the php.ini
* Included a VS code configuration to support XDebugging, but you'll need to install the PHP Debug extension
* The XDEBUG_CONFIG environment variable configures XDebug. The remote host alias allows XDebug to connect to your debugging client (VS code or similar). It needs the 'host.docker.internal' to access the host rather than the container. Note this variable may differ on Linux, but works on MacOS and Windows.