### PR TITLE
Add a missing global variable

### DIFF
--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -17,7 +17,7 @@ Tracer::inSpan(
         // this is horrible, but in order to wrap these includes in this tracing function
         // we have to declare every possible global variable usage
         // ideally we wouldn't be using globals at all, but that's for another day :) 
-        global $settings,$translate,$action,$lan,$pdf,$_txt;
+        global $settings,$translate,$action,$lan,$pdf,$_txt,$formbuttons;
         global $error,$listdata,$data,$table,$listconfig,$thisfile,$formdata;
         switch ($parsedUrl) {
         case '/':


### PR DESCRIPTION
They have to be declared here to work as we're wrapping the entry point in a function. I did another search for 'global $' in the code base to check if I missed any others, but hopefully got them all this time.

A replacement fix for this PR: https://github.com/boxwise/dropapp/pull/100 (https://trello.com/c/AJFbDch4) @HaGuesto can you check this PR resolves the issue for you?