### PR TITLE
Fix MySQL (in Docker) to always use lower case table names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
   db_mysql:
     image: mysql/mysql-server:latest
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     environment:
       MYSQL_ROOT_PASSWORD: dropapp_root
       MYSQL_ROOT_HOST: '%'


### PR DESCRIPTION
This should resolve corruption issues when running on MacOS, and is the one setting (according to the docs) that will work across Windows, Linux and MacOS hosts consistently.