### PR TITLE
Replace any hard-coded HTTP urls to HTTPS

### DIFF
--- a/include/stock-list_edit.php
+++ b/include/stock-list_edit.php
@@ -140,7 +140,7 @@
 				$boxid = db_value('SELECT box_id FROM stock WHERE id = :id',array('id'=>$id));
 				$success = true;
 				$message = '';
-				$redirect = 'https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=http://'.$_SERVER['HTTP_HOST'].'/mobile.php?barcode='.$boxid;
+				$redirect = 'https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=https://'.$_SERVER['HTTP_HOST'].'/mobile.php?barcode='.$boxid;
 				break;
 		    case 'move':
 				$ids = json_decode($_POST['ids']);

--- a/include/stock_edit.php
+++ b/include/stock_edit.php
@@ -72,7 +72,7 @@
 	if($data['qr_id']){
 		$qr = db_value('SELECT code FROM qr WHERE id = :id',array('id'=>$data['qr_id']));
 
-		addfield('html', '', '<img src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=http://'.$_SERVER['HTTP_HOST'].'/mobile.php?barcode='.$qr.'" /><br /><br />', array('aside'=>true, 'asidetop'=>true));
+		addfield('html', '', '<img src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=https://'.$_SERVER['HTTP_HOST'].'/mobile.php?barcode='.$qr.'" /><br /><br />', array('aside'=>true, 'asidetop'=>true));
 	}
 
 	addfield('line');

--- a/library/ajax/reset.php
+++ b/library/ajax/reset.php
@@ -15,9 +15,9 @@ $row = db_row('SELECT *, "org" AS usertype FROM cms_users WHERE email != ""
 		$message = str_ireplace('{sitename}',$translate['site_name'].' ('.$_SERVER['HTTP_HOST'].')',$message);
 
 		if($row['usertype']=='family') {
-			$message = str_ireplace('{link}','http://'.$_SERVER['HTTP_HOST'].'/reset.php?peopleid='.$row['id'].'&hash='.$hash,$message);
+			$message = str_ireplace('{link}','https://'.$_SERVER['HTTP_HOST'].'/reset.php?peopleid='.$row['id'].'&hash='.$hash,$message);
 		} else {
-			$message = str_ireplace('{link}','http://'.$_SERVER['HTTP_HOST'].'/reset.php?userid='.$row['id'].'&hash='.$hash,$message);
+			$message = str_ireplace('{link}','https://'.$_SERVER['HTTP_HOST'].'/reset.php?userid='.$row['id'].'&hash='.$hash,$message);
 		}
 
 		$result = sendmail($row['email'], $row['naam'], $translate['cms_reset_mailsubject'], $message);

--- a/mobile.php
+++ b/mobile.php
@@ -57,7 +57,7 @@ if (!$checksession_result['success']) {
 		//$data['message'] = 'You don\'t have access to this base. Ask your coordinator to correct this!';
 	}
 } elseif (!db_value('SELECT id FROM locations WHERE locations.camp_id = ' . intval($_SESSION['camp']['id']) . ' LIMIT 1 ')) {
-	redirect('http://'.$_SERVER['HTTP_HOST'].'?action=start');
+	redirect('/?action=start');
 } else { # --------------- All routing happens here
 	# Boxlabel is scanned 
 	if ($_GET['barcode'] != '' || $_GET['boxid'] != '') {

--- a/mobile/login.php
+++ b/mobile/login.php
@@ -3,7 +3,8 @@
 $login = login($_POST['email'], $_POST['pass'], $_POST['autologin'], $mobile = true);
 
 if ($login['success']) {
-	redirect('http://' . $_SERVER['HTTP_HOST'] . $_POST['destination']);
+	// WARNING: this is an open redirect, need to review the risk here
+	redirect('/' . $_POST['destination']);
 } else {
 	redirect('?warning=true&message=' . $login['message']);
 }

--- a/templates/boxlabels.tpl
+++ b/templates/boxlabels.tpl
@@ -20,7 +20,7 @@
 </div>
 {else}
 <div class="boxlabel-small">
-	<img src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=http://{$smarty.server.HTTP_HOST}/mobile.php?barcode={$d['hash']}" />
+	<img src="https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=https://{$smarty.server.HTTP_HOST}/mobile.php?barcode={$d['hash']}" />
 </div>
 {/if}
 {/foreach}


### PR DESCRIPTION
On the mobile login page, Cypress is causing errors when resources are loaded via HTTPS but then there's a HTTP redirect. Figured I might as well replace all occurrences rather than this one specific. Part of the work for https://github.com/boxwise/dropapp/pull/57