### PR TITLE
Revert redirect to absolute but stay on HTTPS

### DIFF
--- a/mobile.php
+++ b/mobile.php
@@ -57,7 +57,7 @@ if (!$checksession_result['success']) {
 		//$data['message'] = 'You don\'t have access to this base. Ask your coordinator to correct this!';
 	}
 } elseif (!db_value('SELECT id FROM locations WHERE locations.camp_id = ' . intval($_SESSION['camp']['id']) . ' LIMIT 1 ')) {
-	redirect('/?action=start');
+	redirect('http://'.$_SERVER['HTTP_HOST'].'?action=start');
 } else { # --------------- All routing happens here
 	# Boxlabel is scanned 
 	if ($_GET['barcode'] != '' || $_GET['boxid'] != '') {

--- a/mobile/login.php
+++ b/mobile/login.php
@@ -3,8 +3,7 @@
 $login = login($_POST['email'], $_POST['pass'], $_POST['autologin'], $mobile = true);
 
 if ($login['success']) {
-	// WARNING: this is an open redirect, need to review the risk here
-	redirect('/' . $_POST['destination']);
+	redirect('http://' . $_SERVER['HTTP_HOST'] . $_POST['destination']);
 } else {
 	redirect('?warning=true&message=' . $login['message']);
 }


### PR DESCRIPTION
We were redirecting with two // which broke the relative redirects, and given we have a potential open redirect vulnerability here figured it was safer to stick with absolute.

Fix for https://github.com/boxwise/dropapp/pull/109