### PR TITLE
Trigger exception for no base access rather than an error

### DIFF
--- a/mobile.php
+++ b/mobile.php
@@ -53,7 +53,7 @@ if (!$checksession_result['success']) {
 	if (!isset($_SESSION['organisation']['id']) && $_SESSION['user']['is_admin']) {
 		require_once('mobile/selectorganisation.php');
 	} else {
-		trigger_error('You don\'t have access to this base. Ask your coordinator to correct this!');
+		throw new Exception('You don\'t have access to this base. Ask your coordinator to correct this!');
 		//$data['message'] = 'You don\'t have access to this base. Ask your coordinator to correct this!';
 	}
 } elseif (!db_value('SELECT id FROM locations WHERE locations.camp_id = ' . intval($_SESSION['camp']['id']) . ' LIMIT 1 ')) {


### PR DESCRIPTION
Our sentry handling to provide extra information like $_SESSION data is not triggered by errors, only exceptions. So in order to try and diagnose these issues more easily, switching to an exception.

https://trello.com/c/a172eoFD/243-regression-sentry-scanning-error-large