### PR TITLE
Add tracing to beneficiaries list as this page is very slow

### DIFF
--- a/include/people.php
+++ b/include/people.php
@@ -1,6 +1,7 @@
 <?php
 
-	
+use OpenCensus\Trace\Tracer;
+
 	$table = $action;
 	$ajax = checkajax();
 
@@ -72,63 +73,71 @@
 
 		$daysinactive = db_value('SELECT delete_inactive_users/2 FROM camps WHERE id = '.$_SESSION['camp']['id']);
 
-		foreach($data as $key=>$value) {
-			
-			if($data[$key]['expired']) {
-				$data[$key]['expired'] = '<i class="fa fa-exclamation-triangle warning tooltip-this" title="This family hasn\'t been active for at least '. floor($daysinactive) .' days."></i> '; 
-			} else {
-				$data[$key]['expired'] ='';
-			}
-			if($data[$key]['parent_id']==0 && !$data[$key]['approvalsigned']) {
-				$data[$key]['expired'] .= '<i class="fa fa-pencil-square warning tooltip-this" title="This family didn\'t sign the privacy declaration"></i> ';
-			}
+		Tracer::inSpan(
+			['name' => ('people.php:addhtmldata')],
+		 	function() use ($data) {
+				foreach($data as $key=>$value) {
+					
+					if($data[$key]['expired']) {
+						$data[$key]['expired'] = '<i class="fa fa-exclamation-triangle warning tooltip-this" title="This family hasn\'t been active for at least '. floor($daysinactive) .' days."></i> '; 
+					} else {
+						$data[$key]['expired'] ='';
+					}
+					if($data[$key]['parent_id']==0 && !$data[$key]['approvalsigned']) {
+						$data[$key]['expired'] .= '<i class="fa fa-pencil-square warning tooltip-this" title="This family didn\'t sign the privacy declaration"></i> ';
+					}
 
-			if($data[$key]['bicycletraining'] && $_SESSION['camp']['bicycle']) {
-				$data[$key]['expired'] .= '<i class="fa fa-bicycle tooltip-this" title="This person has a bicycle certificate."></i> ';
-			}
-			if($data[$key]['workshoptraining'] && $_SESSION['camp']['workshop']) {
-				$data[$key]['expired'] .= '<i class="fa fa-wrench tooltip-this '.($data[$key]['workshopsupervisor']?'blue':'').'" title="This person has a workshop certificate."></i> ';
-			}
+					if($data[$key]['bicycletraining'] && $_SESSION['camp']['bicycle']) {
+						$data[$key]['expired'] .= '<i class="fa fa-bicycle tooltip-this" title="This person has a bicycle certificate."></i> ';
+					}
+					if($data[$key]['workshoptraining'] && $_SESSION['camp']['workshop']) {
+						$data[$key]['expired'] .= '<i class="fa fa-wrench tooltip-this '.($data[$key]['workshopsupervisor']?'blue':'').'" title="This person has a workshop certificate."></i> ';
+					}
 
-			if(file_exists($settings['upload_dir'].'/people/'.$data[$key]['id'].'.jpg') && $_SESSION['camp']['idcard']) {
-				$data[$key]['expired'] .= '<i class="fa fa-id-card-o tooltip-this" title="This person has a picture."></i> ';
+					if(file_exists($settings['upload_dir'].'/people/'.$data[$key]['id'].'.jpg') && $_SESSION['camp']['idcard']) {
+						$data[$key]['expired'] .= '<i class="fa fa-id-card-o tooltip-this" title="This person has a picture."></i> ';
+					}
+					if($data[$key]['volunteer']) {
+						$data[$key]['expired'] .= '<i class="fa fa-heart blue tooltip-this" title="This beneficiary is a volunteer."></i> ';
+					}
+				}
 			}
-			if($data[$key]['volunteer']) {
-				$data[$key]['expired'] .= '<i class="fa fa-heart blue tooltip-this" title="This beneficiary is a volunteer."></i> ';
-			}
-		}
+		);
 
-		addcolumn('text','Lastname','lastname');
-		addcolumn('text','Firstname','firstname');
-		addcolumn('text','Gender','gender2');
-		addcolumn('text','Age','age');
-		//addcolumn('text','NR','nr');
-		addcolumn('text',$_SESSION['camp']['familyidentifier'],'container');
-		addcolumn('text', ucwords($_SESSION['camp']['currencyname']),'drops');
-		addcolumn('text', 'Comments','comments');
-		addcolumn('html','&nbsp;','expired');
-		if($listconfig['filtervalue']) addcolumn('datetime','Created','created');
-
-		addbutton('give','Give '.ucwords($_SESSION['camp']['currencyname']),array('image'=>'one_coin.png', 'imageClass'=>'coinsImage','oneitemonly'=>false));
-		addbutton('merge','Merge to family',array('icon'=>'fa-link','oneitemonly'=>false));
-		addbutton('detach','Detach from family',array('icon'=>'fa-unlink','oneitemonly'=>false));
-
-		if($_SESSION['camp']['bicycle']) $options['bicycle'] = 'Bicycle card';
-		if($_SESSION['camp']['id']==1) $options['occ'] = 'OCCycle card';
-		if($_SESSION['camp']['bicycle']) $options['workshop'] = 'Workshop card';
-		if($_SESSION['camp']['idcard']) $options['id'] = 'ID Card';
+		Tracer::inSpan(
+			['name' => ('people.php:addtemplatedata')],
+			function() use ($cmsmain) {
+				global $listdata, $data, $listdata, $listconfig;
+				addcolumn('text','Lastname','lastname');
+				addcolumn('text','Firstname','firstname');
+				addcolumn('text','Gender','gender2');
+				addcolumn('text','Age','age');
+				//addcolumn('text','NR','nr');
+				addcolumn('text',$_SESSION['camp']['familyidentifier'],'container');
+				addcolumn('text', ucwords($_SESSION['camp']['currencyname']),'drops');
+				addcolumn('text', 'Comments','comments');
+				addcolumn('html','&nbsp;','expired');
+				if($listconfig['filtervalue']) addcolumn('datetime','Created','created');
 		
-		addbutton('print','Print',array('icon'=>'fa-print','options'=>$options));
-		addbutton('touch','Touch',array('icon'=>'fa-hand-pointer'));
-
-		addbutton('export','Export',array('icon'=>'fa-download','showalways'=>true));
-
-		$cmsmain->assign('data',$data);
-		$cmsmain->assign('listconfig',$listconfig);
-		$cmsmain->assign('listdata',$listdata);
-		$cmsmain->assign('include','cms_list.tpl');
-
-
+				addbutton('give','Give '.ucwords($_SESSION['camp']['currencyname']),array('image'=>'one_coin.png', 'imageClass'=>'coinsImage','oneitemonly'=>false));
+				addbutton('merge','Merge to family',array('icon'=>'fa-link','oneitemonly'=>false));
+				addbutton('detach','Detach from family',array('icon'=>'fa-unlink','oneitemonly'=>false));
+		
+				if($_SESSION['camp']['bicycle']) $options['bicycle'] = 'Bicycle card';
+				if($_SESSION['camp']['id']==1) $options['occ'] = 'OCCycle card';
+				if($_SESSION['camp']['bicycle']) $options['workshop'] = 'Workshop card';
+				if($_SESSION['camp']['idcard']) $options['id'] = 'ID Card';
+				
+				addbutton('print','Print',array('icon'=>'fa-print','options'=>$options));
+				addbutton('touch','Touch',array('icon'=>'fa-hand-pointer'));
+		
+				addbutton('export','Export',array('icon'=>'fa-download','showalways'=>true));
+				$cmsmain->assign('data',$data);
+				$cmsmain->assign('listconfig',$listconfig);
+				$cmsmain->assign('listdata',$listdata);
+				$cmsmain->assign('include','cms_list.tpl');
+			}
+		);
 	} else {
 		switch ($_POST['do']) {
 		    case 'merge':


### PR DESCRIPTION
In the hope we can track down where a big performance issue lies, add more tracing. To do this we have to wrap into trace functions, which then causes issues because of our implicit global variables - so we need to declare these.

I can't understand why $cmsmain can't be named in the use() list and instead has to be declared as a global.