### PR TITLE
Pre-compile smarty templates

### DIFF
--- a/build.php
+++ b/build.php
@@ -1,3 +1,4 @@
 <?php
 	require "build/pack-css.php";
 	require "build/pack-js.php";
+	require "build/compile-smarty.php";

--- a/build/compile-smarty.php
+++ b/build/compile-smarty.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../library/config.php';
+require_once __DIR__.'/../library/lib/smarty.php';
+$smarty = new Zmarty;
+$smarty->compileAllTemplates('.tpl', true, 0, null);

--- a/library/core.php
+++ b/library/core.php
@@ -11,9 +11,6 @@ require_once('lib/database.php');
 if (!array_key_exists('upload_dir',$settings)) {
     $settings['upload_dir'] = $_SERVER['DOCUMENT_ROOT'].'/uploads';
 }
-if (!array_key_exists('smarty_dir',$settings)) {
-    $settings['smarty_dir'] = $_SERVER['DOCUMENT_ROOT'].'/templates/templates_c';
-}
 
 # connect to database
 if (array_key_exists('db_socket',$settings)) {

--- a/library/gcloud.php
+++ b/library/gcloud.php
@@ -29,7 +29,6 @@ function registerGoogleCloudServices($projectId)
     
     $hostName = @parse_url('http://'.$_SERVER['HTTP_HOST'], PHP_URL_HOST);
     $version = $settings['version'] ?? '0';
-    $settings['smarty_dir'] = sys_get_temp_dir(); //"gs://$projectId.appspot.com/$hostName/v$version/smarty/compile/";
     $settings['upload_dir'] = "gs://$projectId.appspot.com/$hostName/uploads";
 }
 

--- a/library/lib/smarty.php
+++ b/library/lib/smarty.php
@@ -1,6 +1,6 @@
 <?php
-
 use OpenCensus\Trace\Tracer;
+
 class Zmarty extends Smarty {
     public function __construct() {
         global $settings, $translate, $lan;
@@ -14,8 +14,8 @@ class Zmarty extends Smarty {
             $this->debugging = true;
         }
         $this->merge_compiled_includes = true;
-        $this->setCompileDir($settings['smarty_dir']);
-        $this->addTemplateDir($_SERVER['DOCUMENT_ROOT'].'/templates');
+        $this->setCompileDir(__DIR__.'/../../templates/templates_c');
+        $this->addTemplateDir(__DIR__.'/../../templates');
         $this->assign('lan',$lan);
         $this->assign('modal',isset($_GET['modal']));
         $this->assign('translate',$translate);


### PR DESCRIPTION
Pre-compile smarty templates for performance reasons

This way they get deployed to Google AppEngine and there's no more work to do. Previously, we tried using cloud storage as the template folder (super slow). Switching to a temporary folder worked, but you still have a perf hit each time a new instance is initiated.