### PR TITLE
Pre-compile smarty templates for performance reasons

### DIFF
--- a/build.php
+++ b/build.php
@@ -1,3 +1,4 @@
 <?php
 	require "build/pack-css.php";
 	require "build/pack-js.php";
+	require "build/compile-smarty.php";

--- a/build/compile-smarty.php
+++ b/build/compile-smarty.php
@@ -1,5 +1,69 @@
 <?php
 require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/../library/lib/smarty.php';
+# You can’t precompile Smarty on one system and then upload to another server,
+# as the compiled filenames have the absolute path of the source files encoded. 
+
+# /srv is the root path on google app engine
+$deploymentRootFolder = '/srv';
+
+# So, this is a cheeky work-around that rewrites the hashes 
+# in the templates and on the file system so they will match
+# the paths of the target deployment system 
+
+# The hash was reverse engineered from smarty_internal_resource_file.php
 $smarty = new Zmarty;
-$smarty->compileAllTemplates('.tpl', true, 0, null);
+precompileTemplates($smarty);
+echo "Re-mapping templates from '$originalTemplateDir' to '$deployedTemplateDir'\n";
+rewriteAllTemplateHashes($smarty, $deploymentRootFolder);
+
+function precompileTemplates($smarty) {
+    $smarty->clearCompiledTemplate();
+    $smarty->compileAllTemplates('.tpl', true, 0, null);
+}
+
+function rewriteAllTemplateHashes($smarty, $deploymentRootFolder) {
+    $rootDir = realpath(__DIR__.'/../');
+    $originalTemplateDir = $smarty->getTemplateDir()[0];
+    # swap out the root of originalTemplateDir for the new deployment path
+    $deployedTemplateDir = $deploymentRootFolder.str_replace($rootDir,'',$originalTemplateDir);
+
+    $it = new FilesystemIterator($smarty->getCompileDir(),);
+    foreach (glob($smarty->getCompileDir().'*.tpl.php') as $fileName) {
+        rewriteTemplateHash($smarty, $fileName, $originalTemplateDir, $deployedTemplateDir);
+    }
+}
+
+function rewriteTemplateHash($smarty, $templateFileName, $originalTemplateDir, $deployedTemplateDir) {
+    // example file name format:
+    // 5ad5ecef0cb555f346e97a65e3cc109456de7a1a_1.file.mobile_scan.tpl.php
+    echo "Processing compiled template $templateFileName\n";
+    $fileNameParts = explode(".", basename($templateFileName));
+    $originalTemplateHash = $fileNameParts[0];
+    $originalTemplateName = $fileNameParts[2] . "." . $fileNameParts[3];
+    $originalTemplatePath = $originalTemplateDir . $originalTemplateName;
+    # work out what we expect the current hash to be, to ensure it matches
+    # if not, the algorithm has somehow changed, so we'll abort
+    $currentHashInput = $originalTemplatePath.$originalTemplateDir;
+    $currentHash = sha1($currentHashInput);
+    # 0 if merge_compiled_includes is off, 1 if merge_compiled_includes is on
+    # technically we don't rewrite the files correctly with this setting on
+    # as we don't re-hash the embedded templates but it seems to be good 'enough'
+    $suffix = $smarty->merge_compiled_includes ? "_1" : "_0";
+    if ($currentHash . "_1" != $originalTemplateHash)
+        throw new Exception("Failed to anticipate current hash for $templateFileName\nHashed input: $currentHashInput\nCalculated hash: $currentHash\nActual hash: $originalTemplateHash");
+    # 
+    $newTemplatePath = $deployedTemplateDir . $originalTemplateName;
+    # we want to
+    # (a) replace the old file name and hash within the contents of the file
+    #     with the new hash
+    # (b) rename the template so it uses the new hash
+    $newHash = sha1($newTemplatePath.$deployedTemplateDir);
+    $currentTemplate = file_get_contents($templateFileName);
+    $newTemplate = str_replace($currentHash,$newHash,$currentTemplate);
+    $newTemplate = str_replace($originalTemplatePath,$newTemplatePath,$newTemplate);
+    $newTemplateCompiledPath = str_replace($currentHash,$newHash,$templateFileName);
+    echo "Saving new template to $newTemplateCompiledPath and deleting the original\n";
+    file_put_contents($newTemplateCompiledPath,$newTemplate);
+    unlink($templateFileName);
+}

--- a/build/compile-smarty.php
+++ b/build/compile-smarty.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../library/lib/smarty.php';
+$smarty = new Zmarty;
+$smarty->compileAllTemplates('.tpl', true, 0, null);

--- a/library/core.php
+++ b/library/core.php
@@ -11,9 +11,6 @@ require_once('lib/database.php');
 if (!array_key_exists('upload_dir',$settings)) {
     $settings['upload_dir'] = $_SERVER['DOCUMENT_ROOT'].'/uploads';
 }
-if (!array_key_exists('smarty_dir',$settings)) {
-    $settings['smarty_dir'] = $_SERVER['DOCUMENT_ROOT'].'/templates/templates_c';
-}
 
 # connect to database
 if (array_key_exists('db_socket',$settings)) {

--- a/library/gcloud.php
+++ b/library/gcloud.php
@@ -29,7 +29,6 @@ function registerGoogleCloudServices($projectId)
     
     $hostName = @parse_url('http://'.$_SERVER['HTTP_HOST'], PHP_URL_HOST);
     $version = $settings['version'] ?? '0';
-    $settings['smarty_dir'] = sys_get_temp_dir(); //"gs://$projectId.appspot.com/$hostName/v$version/smarty/compile/";
     $settings['upload_dir'] = "gs://$projectId.appspot.com/$hostName/uploads";
 }
 

--- a/library/lib/smarty.php
+++ b/library/lib/smarty.php
@@ -15,7 +15,7 @@ class Zmarty extends Smarty {
         }
         $this->merge_compiled_includes = true;
         $this->setCompileDir(__DIR__.'/../../templates/templates_c');
-        $this->addTemplateDir(__DIR__.'/../../templates');
+        $this->setTemplateDir(__DIR__.'/../../templates');
         $this->assign('lan',$lan);
         $this->assign('modal',isset($_GET['modal']));
         $this->assign('translate',$translate);

--- a/library/lib/smarty.php
+++ b/library/lib/smarty.php
@@ -1,6 +1,6 @@
 <?php
-
 use OpenCensus\Trace\Tracer;
+
 class Zmarty extends Smarty {
     public function __construct() {
         global $settings, $translate, $lan;
@@ -14,8 +14,8 @@ class Zmarty extends Smarty {
             $this->debugging = true;
         }
         $this->merge_compiled_includes = true;
-        $this->setCompileDir($settings['smarty_dir']);
-        $this->addTemplateDir($_SERVER['DOCUMENT_ROOT'].'/templates');
+        $this->setCompileDir(__DIR__.'/../../templates/templates_c');
+        $this->addTemplateDir(__DIR__.'/../../templates');
         $this->assign('lan',$lan);
         $this->assign('modal',isset($_GET['modal']));
         $this->assign('translate',$translate);


### PR DESCRIPTION
This way they get deployed to Google AppEngine and there's no more work to do. Previously, we tried using cloud storage as the template folder (super slow). Switching to a temporary folder worked, but you still have a perf hit each time a new instance is initiated.

You can’t precompile Smarty on one system and then upload to another server, as the compiled filenames have the absolute path of the source files encoded.

So, this is a cheeky work-around that rewrites the hashes.