### PR TITLE
Fix auto-login bug (seen on mobile)

### DIFF
--- a/library/lib/session.php
+++ b/library/lib/session.php
@@ -76,11 +76,11 @@ function checksession()
 			if ($user) {
 				loadSessionData($user);
 				db_query('UPDATE cms_users SET lastlogin = NOW(), lastaction = NOW() WHERE id = :id', array('id' => $_SESSION['user']['id']));
+				return $result;
 			}
-		} else {
-			$result['success'] = false;
-			$result['redirect'] = '/login.php?destination=' . urlencode($_SERVER['REQUEST_URI']);
 		}
+		$result['success'] = false;
+		$result['redirect'] = '/login.php?destination=' . urlencode($_SERVER['REQUEST_URI']);
 	}
 	return $result;
 }

--- a/library/lib/session.php
+++ b/library/lib/session.php
@@ -77,6 +77,9 @@ function checksession()
 				loadSessionData($user);
 				db_query('UPDATE cms_users SET lastlogin = NOW(), lastaction = NOW() WHERE id = :id', array('id' => $_SESSION['user']['id']));
 				return $result;
+			} else {
+				setcookie("autologin_user", null, time() - 3600, '/');
+				setcookie("autologin_pass", null, time() - 3600, '/');
 			}
 		}
 		$result['success'] = false;


### PR DESCRIPTION
Should hopefully fix https://trello.com/c/a172eoFD/243-regression-sentry-scanning-error-large

When a user had an autologin cookie but the login failed, you weren't taken to a login screen. 

Reproduction:
1. Login, checking 'remember me'
2. Change your password
3. Session times out (you can simulate deleing the PHP Session cookie)
4. On desktop, going to boxwise you get a blank page. On mobile, going to mobile.php?barcode, you get an error.

We really shouldn't be storing the md5 of the password client-side) nor should we be using md5, but unable to justify fixing this workflow now