### PR TITLE
Escape all data passed to smarty templates by default

### DIFF
--- a/library/lib/smarty.php
+++ b/library/lib/smarty.php
@@ -13,6 +13,7 @@ class Zmarty extends Smarty {
         if (isset($_GET["smartydebug"])) {
             $this->debugging = true;
         }
+        $this->escape_html = true;
         $this->merge_compiled_includes = true;
         $this->setCompileDir(__DIR__.'/../../templates/templates_c');
         $this->setTemplateDir(__DIR__.'/../../templates');

--- a/templates/cms_form.tpl
+++ b/templates/cms_form.tpl
@@ -1,7 +1,7 @@
 <div class="content-form">
 	<div class="row row-title">
 		<div class="col-sm-12">
-			<h1 id="form-title">{if $title}{$title}{else}{if !$data['id']}{$translate['cms_form_new']}{else}{$translate['cms_form_edit']}{/if}{/if}
+			<h1 id="form-title">{if $title}{$title nofilter}{else}{if !$data['id']}{$translate['cms_form_new']}{else}{$translate['cms_form_edit']}{/if}{/if}
 			</h1> 
 		</div>
 	</div>

--- a/templates/cms_form_custom.tpl
+++ b/templates/cms_form_custom.tpl
@@ -1,7 +1,7 @@
 	<div class="form-group{if $element['hidden']} hidden{/if}" id="div_{$element['field']|strip_tags}">
 		<label for="field" class="control-label col-sm-2">{$element['label']}</label>
 		<div class="col-sm-{if $element['width']>0 and $element['width']<11}{$element['width']}{else}6{/if}">
-	 		<p class="form-control-static">{$element['field']}</p>
+	 		<p class="form-control-static">{$element['field'] nofilter}</p>
 			{if $element['tooltip']}{include file="cms_tooltip.tpl"}{/if}
 		</div>
 	</div>

--- a/templates/start-market.tpl
+++ b/templates/start-market.tpl
@@ -191,12 +191,11 @@ var chart = AmCharts.makeChart( "chartdiv2", {
 <div id="chartdiv2"></div>
 {/if}
 
-	
 	<aside id="aside-container" class="noprint">
 		<div class="affix aside-content">
 		<div class="tipofday">
 			<h3>💡 Tip of the day: {$data['tip']['title']}</h3>
-			<p>{$data['tip']['content']}</p>
+			<p>{$data['tip']['content'] nofilter}</p>
 		</div>
 		</div>
 	</aside>


### PR DESCRIPTION
There are currently lots of potential XSS vulnerabilities - the latest I noticed was message strings being passed in the URL and served up as-is.

 Switching this flag on will mean Smarty will encode all provided input to make it 'safe' for HTML output by default. 

We will need to use 'nofilter' on anywhere that is 'correctly' unescaped - so this PR may break some screens. In general, best practice means any HTML generation should be happening in the template, so fingers crossed there's not too many places this happens.