### PR TITLE
Remove re-throwing exception for PDOException

### DIFF
--- a/library/lib/database.php
+++ b/library/lib/database.php
@@ -84,14 +84,9 @@ function db_query($query, $array = array(), $dbid = false)
 {
 	global $defaultdbid;
 	if (!$dbid) $dbid = $defaultdbid;
-
-	try {
-		$ex = $dbid->prepare($query);
-		$ex->execute($array);
-		return $ex;
-	} catch (PDOException $e) {
-		throw new Exception('db_query() failed: ' . $query . '<br>' . $e->getMessage(), $e->getCode(), $e);
-	}
+	$ex = $dbid->prepare($query);
+	$ex->execute($array);
+	return $ex;
 }
 
 function db_insertid($dbid = false)


### PR DESCRIPTION
PDOException->getCode() doesn't always return an integer, which means you can't always pass down to another Exception. We have enough info in the Sentry stack traces anyway, so I'm just removing the re-throwing.

This was because the errors thrown for https://github.com/boxwise/dropapp/pull/143