### PR TITLE
Enable warnings in local development mode

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,12 +1,15 @@
 <?php
-	
+	$login = false;
+	$ajax = false;
+	$mobile = false;
+
 	require_once('library/core.php');
 	date_default_timezone_set('Europe/Athens');
 	db_query('SET time_zone = "+'.(date('Z')/3600).':00"');
 	
 	# action set by POST will override GET
 	$action = (isset($_POST['action'])?$_POST['action']:(isset($_GET['action'])?$_GET['action']:'start'));
-	$id = intval($_GET['id']);
+	$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 	if ($action == 'logout') logout();
 
 	// dailyroutine is performed when the last action of any user is not of today
@@ -19,7 +22,7 @@
 
 	/* make an organisation menu, if the user is system admin */
 	if($_SESSION['user']['is_admin']) {
-		if($_GET['organisation']) {
+		if(isset($_GET['organisation'])) {
 			unset($_SESSION['camp']);
 			$_SESSION['organisation'] = db_row('SELECT * FROM organisations WHERE id = :id AND (NOT organisations.deleted OR organisations.deleted IS NULL)',array('id'=>$_GET['organisation']));
 		}
@@ -31,7 +34,7 @@
 	
 	# This fills the camp menu in the top bar (only if the user has access to more than 1 camp
 	$camplist = camplist();
-	if($_GET['camp']) $_SESSION['camp'] = $camplist[$_GET['camp']];
+	if(isset($_GET['camp'])) $_SESSION['camp'] = $camplist[$_GET['camp']];
 	elseif(!isset($_SESSION['camp'])) $_SESSION['camp'] = reset($camplist);
 	$cmsmain->assign('camps',$camplist);
 	$cmsmain->assign('currentcamp',$_SESSION['camp']);

--- a/library/ajax/login.php
+++ b/library/ajax/login.php
@@ -1,3 +1,3 @@
 <?php
 
-echo json_encode(login($_POST['email'], $_POST['pass'], $_POST['autologin']));
+echo json_encode(login($_POST['email'], $_POST['pass'], isset($_POST['autologin'])));

--- a/library/error-reporting.php
+++ b/library/error-reporting.php
@@ -1,15 +1,22 @@
 <?php
+
 use OpenCensus\Trace\Tracer;
+
 if (@parse_url($_SERVER['HTTP_HOST'], PHP_URL_HOST) == "localhost") {
     // report all errors in local development
     error_reporting(E_ALL);
+    // dump errors to stderr (you can see in console)
+    // this is so it doesn't interfere with the app interaction
+    ini_set('display_errors', 'stderr');
+    // as we're dumping to stderr, don't show the errors as html
+    ini_set('html_errors', '0');
 } else {
     // report errors, but ignore E_STRICT and E_NOTICE
     error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);
 }
 
 // configure sentry
-if (!array_key_exists("sentry_key",$settings)) {
+if (!array_key_exists("sentry_key", $settings)) {
     throw new Exception("sentry_key must be set to work in GAE environment");
 }
 
@@ -18,10 +25,11 @@ Tracer::inSpan(
     function () {
         global $settings;
         Sentry\init(
-        [
-            'dsn' => $settings['sentry_key'],
-            'environment' => $_SERVER['HTTP_HOST'],
-            'error_types' => error_reporting()
-        ]);
+            [
+                'dsn' => $settings['sentry_key'],
+                'environment' => $_SERVER['HTTP_HOST'],
+                'error_types' => error_reporting()
+            ]
+        );
     }
 );

--- a/library/error-reporting.php
+++ b/library/error-reporting.php
@@ -1,7 +1,12 @@
 <?php
 use OpenCensus\Trace\Tracer;
-// report errors, but ignore E_STRICT and E_NOTICE
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);
+if (@parse_url($_SERVER['HTTP_HOST'], PHP_URL_HOST) == "localhost") {
+    // report all errors in local development
+    error_reporting(E_ALL);
+} else {
+    // report errors, but ignore E_STRICT and E_NOTICE
+    error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_WARNING);
+}
 
 // configure sentry
 if (!array_key_exists("sentry_key",$settings)) {

--- a/library/lib/database.php
+++ b/library/lib/database.php
@@ -45,14 +45,14 @@ function db_value($query, $array = array(), $dbid = false)
 	return $row[0];
 }
 
-function db_array($query, $array = array(), $dbid = false, $idaskey=false)
+function db_array($query, $array = array(), $dbid = false, $idaskey = false)
 {
 	global $defaultdbid;
 	if (!$dbid) $dbid = $defaultdbid;
-
+	$resultarray = null;
 	$result = db_query($query, $array, $dbid);
 	while ($row = db_fetch($result)) {
-		if($idaskey && $row['id']) { 
+		if ($idaskey && $row['id']) {
 			$resultarray[$row['id']] = $row;
 		} else {
 			$resultarray[] = $row;

--- a/mobile/login.php
+++ b/mobile/login.php
@@ -1,6 +1,6 @@
 <?php
 
-$login = login($_POST['email'], $_POST['pass'], $_POST['autologin'], $mobile = true);
+$login = login($_POST['email'], $_POST['pass'], isset($_POST['autologin']), $mobile = true);
 
 if ($login['success']) {
 	# WARNING, this is an open redirect (security issue)

--- a/templates/cms_index.tpl
+++ b/templates/cms_index.tpl
@@ -8,7 +8,7 @@
       <li>
           <ul class="level1">
     {foreach $item['sub'] as $subitem}
-            <li{if $subitem['active']} class="active"{/if}><a class="menu_{$subitem['include']}" href="?action={$subitem['include']}">{$subitem['title']}{if $subitem['alert']}<i class="fa fa-exclamation-circle"></i>{/if}</a></li>
+            <li{if isset($subitem['active'])} class="active"{/if}><a class="menu_{$subitem['include']|default:''}" href="?action={$subitem['include']|default:''}">{$subitem['title']}{if $subitem['alert']}<i class="fa fa-exclamation-circle"></i>{/if}</a></li>
       {/foreach}
           </ul>
       </li>
@@ -32,7 +32,7 @@
 	        <li>
 	            <ul class="level1">
 				{foreach $item['sub'] as $subitem}
-	              <li{if $subitem['active']} class="active"{/if}><a class="menu_{$subitem['include']}" href="?action={$subitem['include']}">{$subitem['title']}{if $subitem['alert']}<i class="fa fa-exclamation-circle"></i>{/if}</a></li>
+	              <li{if isset($subitem['active'])} class="active"{/if}><a class="menu_{$subitem['include']|default:''}" href="?action={$subitem['include']|default:''}">{$subitem['title']}{if $subitem['alert']}<i class="fa fa-exclamation-circle"></i>{/if}</a></li>
 				  {/foreach}
 	            </ul>
 	        </li>
@@ -41,8 +41,8 @@
 	    </div>
 	{/if}
     <div class="content">
-	    {if $include}{include file="{$include}"}{/if}
-	    {if $include2}{include file="{$include2}"}{/if}
+	    {if isset($include)}{include file="{$include}"}{/if}
+	    {if isset($include2)}{include file="{$include2}"}{/if}
     </div>
   </div>
 </div>

--- a/templates/cms_topmenu.tpl
+++ b/templates/cms_topmenu.tpl
@@ -37,7 +37,7 @@
 	 		{/if}
 			
 			<li class="dropdown">
-				<a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user visible-xs"></i><span class="hidden-xs">{$smarty.session.user.naam} {if $smarty.session.user2}({$smarty.session.user2.naam}){/if}</span><b class="caret"></b></a>
+				<a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-user visible-xs"></i><span class="hidden-xs">{$smarty.session.user.naam} {if isset($smarty.session.user2)}({$smarty.session.user2.naam}){/if}</span><b class="caret"></b></a>
 				<ul class="dropdown-menu dropdown-menu-right">
 					<li><a href="?action=cms_profile">{$translate['cms_menu_settings']}</a></li>
 {if $smarty.session.user2}<li><a href="?action=exitloginas">{$translate['cms_menu_exitloginas']|replace:'%user%':$smarty.session.user2.naam}</a></li>{/if}

--- a/templates/start-market.tpl
+++ b/templates/start-market.tpl
@@ -150,7 +150,7 @@ var chart = AmCharts.makeChart( "chartdiv2", {
     <hr />
       {$data['weeklabel']} week, {if $data['newpeople']}<span class="number">{$data['newpeople']}</span>{else}no{/if} new {if $data['newpeople']==1} beneficiary was {else} beneficiaries were {/if} registered in {$currentcamp['name']}.
  			{if isset($data['notregistered'])}
-  				Additionally there {if $data['nonregistered']==1}is {else} are {/if} <span class="number">{$data['notregistered']}</span> unregistered {if $data['notregistered']==1} person{else} people{/if}.
+  				Additionally there {if $data['notregistered']==1}is {else} are {/if} <span class="number">{$data['notregistered']}</span> unregistered {if $data['notregistered']==1} person{else} people{/if}.
   			{/if}
 		</h1>
 	{/if}
@@ -183,11 +183,11 @@ var chart = AmCharts.makeChart( "chartdiv2", {
 </h1>
 
 <hr />
-{if $data['sales']}<h1>Sales in the last 21 days</h1>
+{if isset($data['sales'])}<h1>Sales in the last 21 days</h1>
 <div id="chartdiv"></div>
 {/if}
 <hr />
-{if $data['borrow'] && $smarty.session.camp['bicycle']}<h1>Items lent out in the last 21 days</h1>
+{if isset($data['borrow']) && isset($smarty.session.camp['bicycle'])}<h1>Items lent out in the last 21 days</h1>
 <div id="chartdiv2"></div>
 {/if}
 


### PR DESCRIPTION
Reverts #147 to reinstate #92

This PR is enabling PHP warnings for local development, so we can slowly get the code base to a point there are no warnings. Having the warnings enabled should save us some occasional 'gotchas' with variable scopes and declarations - already found one bug whilst creating this PR having turned on the warnings