### PR TITLE
Add testid tags in form templates

### DIFF
--- a/templates/cms_form_checkbox.tpl
+++ b/templates/cms_form_checkbox.tpl
@@ -2,10 +2,13 @@
 		<input type="hidden" name="__{$element['field']}" value="checkbox {if $element['readonly']}readonly{/if}">
 		<label class="control-label col-sm-2 checkbox-control-label"></label>
 		<div class="col-sm-6">
-			<label for="field_{$element['field']}" class="checkbox"><input type="checkbox" id="field_{$element['field']}" name="{$element['field']}" value="1" {if $data[$element['field']]}checked{/if}  
-			{if $element['readonly']}disabled{/if} 
-			{if $element['required']}required{/if} 
- 			{if $element['onchange']}onchange="{$element['onchange']|escape};"{/if}
+			<label for="field_{$element['field']}" class="checkbox">
+			<input type="checkbox" id="field_{$element['field']}" name="{$element['field']}" value="1" 
+				{if $data[$element['field']]}checked{/if}  
+				{if $element['readonly']}disabled{/if} 
+				{if $element['required']}required{/if} 
+ 				{if $element['onchange']}onchange="{$element['onchange']|escape};"{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			> {$element['label']}
 				{if $element['tooltip']}{include file="cms_tooltip.tpl"}{/if}
 			</label>

--- a/templates/cms_form_date.tpl
+++ b/templates/cms_form_date.tpl
@@ -10,6 +10,7 @@
 					{if $element['onblur']}onblur="{$element['onblur']|escape};"{/if}
 					{if $element['onchange']}onchange="{$element['onchange']|escape};"{/if}
 					{if $element['onkeyup']}onkeyup="{$element['onkeyup']|escape};"{/if}
+					{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 				/>
 				<span class="input-group-addon"><span class="fa {if $element['date']}fa-calendar{else}fa-clock-o{/if}"></span></span>
 			</div>

--- a/templates/cms_form_email.tpl
+++ b/templates/cms_form_email.tpl
@@ -7,8 +7,9 @@
  				{if $element['onchange']}onchange="{$element['onchange']|escape};"{/if}
 	 			onkeyup="setExternalText(this, '#test');{$element['onkeyup']|escape};" 
 	 			onblur="setExternalInput(this, '#test');{$element['onblur']|escape};" 
-			{if $element['readonly'] || $element['locked']}readonly{/if} 
-			{if $element['required']}required{/if} 
+				{if $element['readonly'] || $element['locked']}readonly{/if} 
+				{if $element['required']}required{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>
 			{if $element['locked']}<span class="input-group-btn"><button class="btn btn-default unlock" type="button"><span class="fa"></span></button></span></div>{/if}
 			{if $element['tooltip']}{include file="cms_tooltip.tpl"}{/if}

--- a/templates/cms_form_location.tpl
+++ b/templates/cms_form_location.tpl
@@ -15,7 +15,8 @@
 	 			onblur="setExternalInput(this, '#test');{$element['onblur']|escape};" 
 				{if $element['minlength']}minlength="{$element['minlength']}"{/if}
 				{if $element['readonly'] || $element['locked']}readonly{/if} 
-				{if $element['required']}required{/if} 
+				{if $element['required']}required{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>
 			{if $element['locked']}<span class="input-group-btn"><button class="btn btn-default unlock" type="button"><span class="fa"></span></button></span></div>{/if}
 			{if $element['maxlength']}<p class="counter-parent safe"><span class="counter">{$element['maxlength']}</span> tekens over van {$element['maxlength']}</p>{/if}

--- a/templates/cms_form_number.tpl
+++ b/templates/cms_form_number.tpl
@@ -18,7 +18,8 @@
 				{if $element['minlength']}minlength="{$element['minlength']}"{/if}
 				{if $element['min']}min="{$element['min']}"{/if}
 				{if $element['readonly'] || $element['locked']}readonly{/if} 
-				{if $element['required']}required{/if} 
+				{if $element['required']}required{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>
 			{if $element['locked']}<span class="input-group-btn"><button class="btn btn-default unlock" type="button"><span class="fa"></span></button></span></div>{/if}
 			{if $element['maxlength']}<p class="counter-parent safe"><span class="counter">{$element['maxlength']}</span> tekens over van {$element['maxlength']}</p>{/if}

--- a/templates/cms_form_password.tpl
+++ b/templates/cms_form_password.tpl
@@ -13,7 +13,8 @@
 				{if $element['disableautocomplete']}autocomplete="new-password"{/if}
 				
 				{if $element['readonly'] || $element['locked']}readonly{/if} 
-				{if $element['required']}required{/if}>
+				{if $element['required']}required{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}>
 			{if $element['tooltip']}{include file="cms_tooltip.tpl"}{/if}
 		</div>
 	</div>

--- a/templates/cms_form_select.tpl
+++ b/templates/cms_form_select.tpl
@@ -8,6 +8,7 @@
 				{if $element['required']}required{/if} 
 				{if $element['formatlist']} data-format-list="{$element['formatlist']}"{/if}
 				{if isset($element['onchange'])}onchange="{$element['onchange']|escape};"{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>
 			<option></option>
 			{foreach $element['options'] as $option}

--- a/templates/cms_form_text.tpl
+++ b/templates/cms_form_text.tpl
@@ -17,6 +17,7 @@
 				{if $element['minlength']}minlength="{$element['minlength']}"{/if}
 				{if $element['readonly'] || $element['locked']}readonly{/if} 
 				{if $element['required']}required{/if}
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>
 			{if $element['locked']}<span class="input-group-btn"><button class="btn btn-default unlock" type="button"><span class="fa"></span></button></span></div>{/if}
 			{if $element['maxlength']}<p class="counter-parent safe"><span class="counter">{$element['maxlength']}</span> tekens over van {$element['maxlength']}</p>{/if}

--- a/templates/cms_form_textarea.tpl
+++ b/templates/cms_form_textarea.tpl
@@ -8,8 +8,7 @@
  				{if $element['onblur']}onblur="{$element['onblur']|escape};"{/if}
  				{if $element['onchange']}onchange="{$element['onchange']|escape};"{/if}
  				{if $element['onkeyup']}onkeyup="{$element['onkeyup']|escape};"{/if}
-
-
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 				>{$data[$element['field']]}</textarea>
 			{if $element['maxlength']}<p class="counter-parent safe"><span class="counter">{$element['maxlength']}</span> {$translate['cms_form_charactersleft']|replace:'%n':$element['maxlength']}</p>{/if}
 			{if $element['tooltip']}{include file="cms_tooltip.tpl" valign=" middle"}{/if}

--- a/templates/cms_form_url.tpl
+++ b/templates/cms_form_url.tpl
@@ -15,6 +15,7 @@
 	 			onblur="{$element['onblur']|escape:'quotes'};" 
 				{if $element['minlength']}minlength="{$element['minlength']}"{/if}
 				{if $element['required']}required{/if} readonly
+				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>
 			{if !$data['url_locked']}
 				<span class="input-group-btn"><button class="btn btn-default unlock" type="button"><span class="fa"></span></button></span></div>


### PR DESCRIPTION
@naphets123 @DurkoMatko 
I added the `data-testid` tags to the smarty form templates.
If you want to tag a certain field in a form in the future, you just have to write for example
`addfield('text', 'Lastname', 'lastname', ['testid'=>'lastname']);`
in the corresponding php include file.