### PR TITLE
Don't load Heap analytics at all when on localhost

### DIFF
--- a/templates/analytics.tpl
+++ b/templates/analytics.tpl
@@ -33,15 +33,9 @@
         </script>
     {/literal}
 {/if}
+{if $smarty.server.HTTP_HOST == 'app.boxwise.co' || $smarty.server.HTTP_HOST == 'staging.boxwise.co'}
 <script>
-{if $smarty.server.HTTP_HOST == 'app.boxwise.co'}
-    const heapProjectId = '1677886010';
-{elseif $smarty.server.HTTP_HOST == 'staging.boxwise.co'}
-    const heapProjectId = '17989829';
-{else}
-    const heapProjectId = '';
-{/if}
-
+    const heapProjectId = {($smarty.server.HTTP_HOST == 'app.boxwise.co') ? '1677886010' : '17989829' };
     const userId = "{$smarty.session.user.id}";
     const organisationId = "{$smarty.session.organisation.label}";
     const isAdmin = "{$smarty.session.user.is_admin}";
@@ -57,3 +51,4 @@
     {/literal}
     {/if}
 </script>
+{/if}


### PR DESCRIPTION
As it doesn't record anything anyway and was triggering cypress warnings