### PR TITLE
Change Migration NewUserMgmt to rename settings table

### DIFF
--- a/db/migrations/20190613211018_new_user_mgmt.php
+++ b/db/migrations/20190613211018_new_user_mgmt.php
@@ -132,92 +132,10 @@ class NewUserMgmt extends AbstractMigration
             ])
             ->save()
         ;
-        $this->table('cms_settings', [
-            'id' => false,
-            'primary_key' => ['id'],
-            'engine' => 'InnoDB',
-            'encoding' => 'utf8',
-            'collation' => 'utf8_general_ci',
-            'comment' => '',
-            'row_format' => 'DYNAMIC',
-        ])
-            ->addColumn('id', 'integer', [
-                'null' => false,
-                'limit' => MysqlAdapter::INT_REGULAR,
-                'signed' => false,
-                'identity' => 'enable',
-            ])
-            ->addColumn('category_id', 'integer', [
-                'null' => false,
-                'limit' => MysqlAdapter::INT_REGULAR,
-                'signed' => false,
-                'after' => 'id',
-            ])
-            ->addColumn('type', 'string', [
-                'null' => true,
-                'limit' => 20,
-                'collation' => 'utf8_general_ci',
-                'encoding' => 'utf8',
-                'after' => 'category_id',
-            ])
-            ->addColumn('code', 'string', [
-                'null' => false,
-                'limit' => 255,
-                'collation' => 'utf8_general_ci',
-                'encoding' => 'utf8',
-                'after' => 'type',
-            ])
-            ->addColumn('description', 'string', [
-                'null' => true,
-                'limit' => 255,
-                'collation' => 'utf8_general_ci',
-                'encoding' => 'utf8',
-                'after' => 'code',
-            ])
-            ->addColumn('options', 'string', [
-                'null' => true,
-                'limit' => 255,
-                'collation' => 'utf8_general_ci',
-                'encoding' => 'utf8',
-                'after' => 'description',
-            ])
-            ->addColumn('value', 'text', [
-                'null' => true,
-                'limit' => 65535,
-                'collation' => 'utf8_general_ci',
-                'encoding' => 'utf8',
-                'after' => 'options',
-            ])
-            ->addColumn('hidden', 'integer', [
-                'null' => false,
-                'default' => '0',
-                'limit' => MysqlAdapter::INT_TINY,
-                'after' => 'value',
-            ])
-            ->addColumn('created', 'datetime', [
-                'null' => true,
-                'after' => 'hidden',
-            ])
-            ->addColumn('created_by', 'integer', [
-                'null' => true,
-                'limit' => MysqlAdapter::INT_REGULAR,
-                'after' => 'created',
-            ])
-            ->addColumn('modified', 'datetime', [
-                'null' => true,
-                'after' => 'created_by',
-            ])
-            ->addColumn('modified_by', 'integer', [
-                'null' => true,
-                'limit' => MysqlAdapter::INT_REGULAR,
-                'after' => 'modified',
-            ])
-            ->addIndex(['code'], [
-                'name' => 'code',
-                'unique' => true,
-            ])
-            ->create()
-        ;
+        $this->table('settings')
+            ->rename('cms_settings')
+            ->save()
+            ;
         $this->table('cms_usergroups', [
             'id' => false,
             'primary_key' => ['id'],
@@ -396,6 +314,11 @@ class NewUserMgmt extends AbstractMigration
                 'limit' => MysqlAdapter::INT_REGULAR,
                 'after' => 'modified',
             ])
+            ->addColumn('deleted', 'datetime', [
+                'null' => true,
+                'after' => 'modified_by',
+                'default' => null,
+            ])
             ->create()
         ;
         $this->table('cms_access')->drop()->save();
@@ -406,7 +329,6 @@ class NewUserMgmt extends AbstractMigration
         $this->table('pagetree')->drop()->save();
         $this->table('products_prices')->drop()->save();
         $this->table('redirect')->drop()->save();
-        $this->table('settings')->drop()->save();
         $this->table('settings_categories')->drop()->save();
     }
 }


### PR DESCRIPTION
@jamescrowley I changed one of the first migrations to make it easier for the migration of Drop in the Ocean. 

The settings table should be renamed from `settings` to `cms_settings` and not just dropped and created. Probably, the migration was created by the phinx generator and it did not recognize that a table was renamed.

