### PR TITLE
Remove unused Db library code

### DIFF
--- a/library/lib/form.php
+++ b/library/lib/form.php
@@ -160,34 +160,10 @@
         $formbuttons[] = ['action' => $action, 'label' => $label];
     }
 
-    function getmultilanguagedata($table, $id)
-    {
-        global $settings;
-
-        $hasSubtable = in_array($table.'_content', db_listtables());
-
-        $data = db_row('SELECT * FROM '.$table.' WHERE id = :id', ['id' => $id]);
-
-        if ($hasSubtable) {
-            foreach ($settings['languages'] as $language) {
-                $row2 = db_row('SELECT pc.* FROM '.$table.' AS p, '.$table.'_content AS pc, languages AS l WHERE pc.lan = l.id AND pc.table_id = p.id AND table_id = '.$id.' AND l.code = "'.$language['code'].'"');
-                $data2 = [];
-                foreach ($row2 as $key => $value) {
-                    $data2[$language['code'].'['.$key.']'] = $value;
-                }
-
-                $data = array_merge($data, $data2);
-            }
-        }
-
-        return $data;
-    }
-
     function getParentarray($table, $minlevel, $maxlevel, $field, $level = 0, $parent = 0)
     {
         global $settings, $translate;
 
-        $hasSubtable = in_array($table.'_content', db_listtables($table));
         $hasDeleted = in_array('deleted', db_listfields($table));
         $hasSeq = in_array('seq', db_listfields($table));
 
@@ -197,11 +173,7 @@
             $parentarray[] = ['value' => 0, 'label' => $translate['cms_form_selectroot'], 'level' => $level, 'disabled' => ($minlevel > 0)];
         }
 
-        if ($hasSubtable) {
-            $result = db_query('SELECT a.id, b.'.$field.' FROM '.$table.' AS a, '.$table.'_content AS b WHERE b.lan = :lan AND b.table_id = a.id AND a.parent_id = '.$parent.($hasDeleted ? ' AND NOT a.deleted' : '').' ORDER BY '.($hasSeq ? 'a.seq' : 'a.menutitle ASC'), ['lan' => $lan]);
-        } else {
-            $result = db_query('SELECT a.id, a.'.$field.', a.parent_id FROM '.$table.' AS a WHERE a.parent_id = '.$parent.($hasDeleted ? ' AND NOT a.deleted' : '').' ORDER BY '.($hasSeq ? 'a.seq' : 'a.menutitle ASC'));
-        }
+        $result = db_query('SELECT a.id, a.'.$field.', a.parent_id FROM '.$table.' AS a WHERE a.parent_id = '.$parent.($hasDeleted ? ' AND NOT a.deleted' : '').' ORDER BY '.($hasSeq ? 'a.seq' : 'a.menutitle ASC'));
 
         while ($row = db_fetch($result)) {
             if ($level < $maxlevel) {

--- a/library/lib/list.php
+++ b/library/lib/list.php
@@ -172,69 +172,15 @@ function listCopy($table, $ids, $field)
 {
     global $translate;
 
-    $hasSubtable = db_tableexists($table.'_content');
     $fieldexists = db_fieldexists($table, $field);
-    $hasChildren = db_fieldexists($table, 'parent_id');
 
     if (!$fieldexists) {
         return [false, $translate['cms_list_copyfailure'], true];
     }
 
-    if ($hasSubtable) {
-        listCopy_multilanguage($ids, $table, $field);
-    } else {
-        listCopy_single($ids, $table, $field);
-    }
+    listCopy_single($ids, $table, $field);
 
     return [true, $translate['cms_list_copysuccess'], true];
-}
-
-function listCopy_multilanguage($ids, $table, $field = false, $newparent = false)
-{
-    global $translate;
-
-    foreach ($ids as $id) {
-        $row = db_row('SELECT * FROM '.$table.' WHERE id = :id', ['id' => $id]);
-
-        array_shift($row);
-        $keys = array_keys($row);
-        $keys2 = [];
-
-        if (in_array('seq', $keys)) {
-            $row['seq'] = intval(db_value('SELECT seq FROM '.$table.' ORDER BY seq DESC LIMIT 1')) + 1;
-        }
-        if ($newparent) {
-            $row['parent_id'] = $newparent;
-        }
-        foreach ($keys as $key) {
-            $keys2[] = ':'.$key;
-        }
-
-        db_query('INSERT INTO '.$table.' ('.join(',', $keys).') VALUES ('.join(',', $keys2).')', $row);
-        $new = db_insertid();
-
-        $result = db_query('SELECT * FROM '.$table.'_content WHERE table_id = :id', ['id' => $id]);
-        while ($subrow = db_fetch($result)) {
-            array_shift($subrow);
-            $subkeys = array_keys($subrow);
-            $subkeys2 = [];
-            $subrow['table_id'] = $new;
-            foreach ($subkeys as $subkey) {
-                $subkeys2[] = ':'.$subkey;
-            }
-            if ($field) {
-                $subrow[$field] .= ' '.$translate['cms_list_copy_suffix'];
-            }
-            db_query('INSERT INTO '.$table.'_content ('.join(',', $subkeys).') VALUES ('.join(',', $subkeys2).')', $subrow);
-        }
-
-        $result = db_query('SELECT * FROM '.$table.' WHERE parent_id = :id', ['id' => $id]);
-        while ($child = db_fetch($result)) {
-            listCopy_multilanguage([$child['id']], $table, $field, $new);
-        }
-    }
-
-    return $newids;
 }
 
 function listCopy_single($ids, $table, $field = false)
@@ -457,7 +403,7 @@ function addpagemenu($code, $label, $options = [])
 
 function getlistdata($query, $parent = 0)
 {
-    global $table, $settings, $listconfig, $action;
+    global $table, $listconfig;
 
     $hasTree = db_fieldexists($table, 'parent_id');
     $hasSeq = db_fieldexists($table, 'seq');
@@ -467,23 +413,6 @@ function getlistdata($query, $parent = 0)
     $hasFilter2 = $listconfig['filtervalue2'];
     $hasFilter3 = $listconfig['filtervalue3'];
     $hasFilter4 = $listconfig['filtervalue4'];
-
-    $hasSubtable = db_tableexists($table.'_content');
-
-    $lan = $settings['languages'][0]['id'];
-
-    if ($hasSubtable) {
-        $subfields = db_listfields($table.'_content');
-        array_shift($subfields);
-
-        $pos = stripos($query, ' FROM '.$table) + strlen(' FROM '.$table);
-        $subquery = '
-				LEFT OUTER JOIN '.$table.'_content
-					ON '.$table.'_content.table_id = '.$table.'.id
-					AND '.$table.'_content.lan = '.$lan;
-
-        $query = 'SELECT '.$table.'.*, '.$table.'_content.'.join(',', $subfields).' FROM '.$table.' '.$subquery.' '.substr($query, $pos);
-    }
 
     if ($hasTree) {
         $query = insertwhere($query, 'parent_id = :parent_id');


### PR DESCRIPTION
https://trello.com/c/FT4mJYcL/261-manage-beneficiaries-performance 

While investigating the performance of the beneficiaries page - and specifically https://github.com/boxwise/dropapp/blob/5eea7160ef85e4a5d2ed68ef1450e0a0c111d16e/library/lib/list.php#L492-L495 and https://github.com/boxwise/dropapp/blob/5eea7160ef85e4a5d2ed68ef1450e0a0c111d16e/library/lib/list.php#L399-L408 , I have noticed that (a) only the cms_functions and people table have a parent_id (the problematic performance scenario and (b) that we have no functions ending in _content.

As such, can simplify a bunch of code. This is the first step.

We have no tables that end in _content, so none of these code paths are used. Identified while trying to optimise getlistdata. To do this PR, I
- searched for all occurrences of _content in our code base
- removed the direct code using it
- removed any dependent code using it (and established that nothing was using it outside of library)