### PR TITLE
Improve performance of beneficiaries page

### DIFF
--- a/include/cms_functions.php
+++ b/include/cms_functions.php
@@ -11,7 +11,7 @@
 
         $cmsmain->assign('title', $translate['cms_functions']);
 
-        $data = getlistdata('SELECT cms_functions.*, IF(parent_id=0,0,1) AS editable FROM cms_functions LEFT OUTER JOIN cms_functions_camps AS x ON x.cms_functions_id = cms_functions.id LEFT OUTER JOIN camps AS c ON c.id = x.camps_id GROUP BY cms_functions.id ORDER BY cms_functions.seq');
+        $data = gettreedata('SELECT cms_functions.*, IF(parent_id=0,0,1) AS editable FROM cms_functions LEFT OUTER JOIN cms_functions_camps AS x ON x.cms_functions_id = cms_functions.id LEFT OUTER JOIN camps AS c ON c.id = x.camps_id GROUP BY cms_functions.id ORDER BY cms_functions.seq');
 
         if (db_fieldexists($table, 'title_'.$lan)) {
             addcolumn('text', 'Functie', 'title_'.$lan);

--- a/include/people.php
+++ b/include/people.php
@@ -32,7 +32,7 @@ $table = $action;
 
         $search = substr(db_escape(trim($listconfig['searchvalue'])), 1, strlen(db_escape(trim($listconfig['searchvalue']))) - 2);
 
-        $data = getlistdata('
+        $data = gettreedata('
 		SELECT 
 			IF(DATEDIFF(NOW(),
 			IF(people.parent_id,NULL,GREATEST(COALESCE((SELECT transaction_date 

--- a/include/people.php
+++ b/include/people.php
@@ -32,7 +32,7 @@ $table = $action;
 
         $search = substr(db_escape(trim($listconfig['searchvalue'])), 1, strlen(db_escape(trim($listconfig['searchvalue']))) - 2);
 
-        $data = gettreedata('
+        $data = getlistdata('
 		SELECT 
 			IF(DATEDIFF(NOW(),
 			IF(people.parent_id,NULL,GREATEST(COALESCE((SELECT transaction_date 
@@ -43,12 +43,14 @@ $table = $action;
 			)) > (SELECT delete_inactive_users/2 FROM camps WHERE id = '.$_SESSION['camp']['id'].'),1,NULL) AS expired,
 			people.*, 
 			DATE_FORMAT(FROM_DAYS(DATEDIFF(NOW(), people.date_of_birth)), "%Y")+0 AS age, 
-			IF(gender="M","Male",IF(gender="F","Female","")) AS gender2, 
+			IF(people.gender="M","Male",IF(people.gender="F","Female","")) AS gender2, 
 			IF(people.parent_id,"",SUM(t2.drops)) AS drops,  
-			IF(notregistered,"NR","") AS nr,
-			comments
-		FROM people 
-		LEFT OUTER JOIN transactions AS t2 ON t2.people_id = people.id 
+			IF(people.notregistered,"NR","") AS nr,
+            people.comments,
+            IF(people.parent_id,1,0) AS level
+        FROM people 
+        LEFT OUTER JOIN transactions AS t2 ON t2.people_id = people.id 
+        LEFT OUTER JOIN people AS parent ON parent.id = people.parent_id
 		WHERE 
 			NOT people.deleted AND 
 			'.('week' == $listconfig['filtervalue'] ? ' DATE_FORMAT(NOW(),"%v-%x") = DATE_FORMAT(people.created,"%v-%x") AND' : '').
@@ -60,7 +62,7 @@ $table = $action;
 			 container = "'.$search.'" OR 
 			 comments LIKE "%'.$search.'%" OR 
 			 (SELECT 
-			 	COUNT(id) 
+			 	COUNT(id)
 			 FROM people AS p 
 			 WHERE 
 			 	(lastname LIKE "%'.$search.'%" OR 
@@ -70,7 +72,7 @@ $table = $action;
 			 	 p.parent_id = people.id AND NOT p.deleted AND p.camp_id = '.$_SESSION['camp']['id'].'
 			 ))
 			' : ' ')
-        .'GROUP BY people.id ORDER BY people.seq');
+        .'GROUP BY people.id ORDER BY IF(people.parent_id,parent.seq + (people.seq / 100000), people.seq)');
 
         $daysinactive = db_value('SELECT delete_inactive_users/2 FROM camps WHERE id = '.$_SESSION['camp']['id']);
 


### PR DESCRIPTION
By removing N+1 db query.

Instead of separately querying each row for its parent, we sort the results from the database
and order them such that for each parent, its direct children appear immediately next in the list.

Ideally we'd use a CTE for this, but Google Cloud SQL doesn't support MySQL 8 yet (which is when this became supported) so instead we'll do a poor man's version here and compute on the fly.

In order to preserve arbitrary sorting, we record the index of the row returned from the database, and build a 'path' representing it.