### PR TITLE
Add the cron job back so we can manually trigger resetting of staging & demo

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,5 +1,9 @@
 cron:
-# - description: "daily reseed demo job"
-#   url: /reseed-db.php
-#   target: demo
-#   schedule: every saturday 05:00
+- description: "reseed staging job"
+  url: /reseed-db.php
+  target: staging
+  schedule: every 99999 hours
+- description: "reseed demo job"
+  url: /reseed-db.php
+  target: staging
+  schedule: every 99999 hours


### PR DESCRIPTION
Adding the cron job which means it will appear in the google app engine console and can be manually triggered. Given https://github.com/boxwise/dropapp/pull/201 requires re-setting the staging db, this means we can do it without faffing connecting to databases in future.

They will in theory run automatically once every 11 years which should be ok for now (unfortunately no way to stop this entirely). Apologies to someone reading this in 11 years time.