### PR TITLE
Rewrite some minor history for schema migrations

### DIFF
--- a/db/migrations/20190622184117_add_organization_ids_to_cms_users_table.php
+++ b/db/migrations/20190622184117_add_organization_ids_to_cms_users_table.php
@@ -263,7 +263,7 @@ class AddOrganizationIdsToCmsUsersTable extends AbstractMigration
             'row_format' => 'DYNAMIC',
         ])
             ->addColumn('organisation_id', 'integer', [
-                'null' => false,
+                'null' => true,
                 'limit' => MysqlAdapter::INT_REGULAR,
                 'signed' => false,
                 'after' => 'valid_lastday',

--- a/db/migrations/20190623123844_add_foreign_keys_in_user_mgmt.php
+++ b/db/migrations/20190623123844_add_foreign_keys_in_user_mgmt.php
@@ -26,7 +26,7 @@ class AddForeignKeysInUserMgmt extends AbstractMigration
             ->changeColumn('userlevel', 'integer', [
                 'signed' => false,
             ])
-            ->addForeignKey('userlevel', 'cms_usergroups', 'id', [
+            ->addForeignKey('userlevel', 'cms_usergroups_levels', 'id', [
                 'delete' => 'RESTRICT', 'update' => 'CASCADE',
             ])
             ->save()


### PR DESCRIPTION
These have already been applied to production, but make the DiH migration a little easier.

- organisation_id on cms_users is created as nullable. This column gets changed to nullable in the next step anyway, so this stops them all going to 0 instead of null when the column is created
- userlevel FK points to the correct FK table. This FK was incorrect and gets fixed in 20190701120113_fix_usergroups_foreign_key - this stops unnecessary errors being triggered on data.

