### PR TITLE
Fix inability to save profile

### DIFF
--- a/include/cms_profile.php
+++ b/include/cms_profile.php
@@ -10,7 +10,7 @@
         }
 
         $handler = new formHandler($table);
-        $handler->savePost($keys);
+        $handler->savePost($keys, ['language']);
 
         $row = db_row('SELECT * FROM '.$table.' WHERE id = :id ', ['id' => $_SESSION['user']['id']]);
         $_SESSION['user'] = array_merge($_SESSION['user'], $row);


### PR DESCRIPTION
Since introducing FKs the 'translate' column is nullable, so needs to be marked as such rather than empty/0

Fixes https://trello.com/c/rNKD8pZv/320-editing-your-own-profile-throws-an-exception