### PR TITLE
Set itemsout from_location to be nullable

### DIFF
--- a/db/migrations/20190923140058_foreign_key_locations.php
+++ b/db/migrations/20190923140058_foreign_key_locations.php
@@ -33,7 +33,7 @@ class ForeignKeyLocations extends AbstractMigration
     {
         $this->table('itemsout')
             ->changeColumn('from_location', 'integer', [
-                'null' => false,
+                'null' => true,
             ])
             ->changeColumn('to_location', 'integer', [
                 'null' => false,

--- a/db/migrations/20191013180000_itemsout_nullable.php
+++ b/db/migrations/20191013180000_itemsout_nullable.php
@@ -1,0 +1,14 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ItemsOutNullable extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('itemsout')
+            ->changeColumn('from_location', 'integer', [
+                'null' => true,
+            ])->save();
+    }
+}


### PR DESCRIPTION
As we have data in DiH where the from_location doesn't exist but the to_location does, and we want to preserve. We rewrite history so we don't lose the data.