### PR TITLE
Fix beneficiary list ordering - change to last/first name

### DIFF
--- a/include/people.php
+++ b/include/people.php
@@ -72,7 +72,17 @@ $table = $action;
 			 	 p.parent_id = people.id AND NOT p.deleted AND p.camp_id = '.$_SESSION['camp']['id'].'
 			 ))
 			' : ' ')
-        .'GROUP BY people.id ORDER BY IF(people.parent_id,parent.seq + (people.seq / 100000), people.seq), IF(people.parent_id,1,0)');
+        .'GROUP BY people.id 
+        ORDER BY 
+            -- sort by *parent* seq (or own seq if no parent)
+            IF(people.parent_id, parent.seq, people.seq),
+            -- children should be grouped with their parents
+            If(people.parent_id, parent.id, people.id),
+            -- parents should appear before children
+            IF(people.parent_id, 1, 0),
+            -- children ordered by seq too
+            IF(people.parent_id, people.seq, 0)
+            ');
 
         $daysinactive = db_value('SELECT delete_inactive_users/2 FROM camps WHERE id = '.$_SESSION['camp']['id']);
 

--- a/include/people.php
+++ b/include/people.php
@@ -14,7 +14,7 @@ $table = $action;
         $cmsmain->assign('title', 'Beneficiaries');
 
         listsetting('allowcopy', false);
-        listsetting('allowmove', false);
+        listsetting('allowmove', true);
         listsetting('allowmoveto', 1);
         listsetting('allowsort', false);
         listsetting('allowshowhide', false);

--- a/include/people.php
+++ b/include/people.php
@@ -14,7 +14,7 @@ $table = $action;
         $cmsmain->assign('title', 'Beneficiaries');
 
         listsetting('allowcopy', false);
-        listsetting('allowmove', true);
+        listsetting('allowmove', false);
         listsetting('allowmoveto', 1);
         listsetting('allowsort', false);
         listsetting('allowshowhide', false);
@@ -74,14 +74,16 @@ $table = $action;
 			' : ' ')
         .'GROUP BY people.id 
         ORDER BY 
-            -- sort by *parent* seq (or own seq if no parent)
-            IF(people.parent_id, parent.seq, people.seq),
+            -- sort by *parent* first & last name (or own first/last if no parent)
+            IF(people.parent_id, parent.lastname, people.lastname), 
+            IF(people.parent_id, parent.firstname, people.firstname),
             -- children should be grouped with their parents
             If(people.parent_id, parent.id, people.id),
             -- parents should appear before children
             IF(people.parent_id, 1, 0),
-            -- children ordered by seq too
-            IF(people.parent_id, people.seq, 0)
+            -- children ordered by first name & last name too
+            IF(people.parent_id, people.lastname, ""), 
+            IF(people.parent_id, people.firstname, "")
             ');
 
         $daysinactive = db_value('SELECT delete_inactive_users/2 FROM camps WHERE id = '.$_SESSION['camp']['id']);


### PR DESCRIPTION
We're ignoring the seq column as it's just a bit weird, so now prevent allowing to move items around in the list.

Also fixing bugs in this ordering as reported by DiH, due to dodgy logic on my part. We need to order the columns for the parents first, then ensure children are grouped with them, by ordering on their *parents* data first. Ideally I'd write tests for these kinds of things, but we haven't set up integration style tests yet.