### PR TITLE
Remove all instances of $_SESSION['camp'] in ajax checkout call.

### DIFF
--- a/include/check_out.php
+++ b/include/check_out.php
@@ -51,7 +51,7 @@
         $cmsmain->assign('formelements', $formdata);
         $cmsmain->assign('formbuttons', $formbuttons);
     } else {
-        if ($_POST['do'] == 'delete') {
+        if ('delete' == $_POST['do']) {
             $ids = explode(',', $_POST['ids']);
             // check if person is allowed to delete transaction
             foreach ($ids as $id) {


### PR DESCRIPTION
Instead of glueing together how the session data is set in an ajax call, I decided to rather remove all references of `$_SESSION['camp']` in the check_out ajax section.
This way we reduce the usage of the session data and hopefully figure out other places where we can replace them.
It was possible since the ajax-call passes data in a POST request from which the camp can be derived.
For security I added a general check if the user has access to the requested camp.

### trello ticket
https://trello.com/c/kgQs1Vah

### sentry issue
DROPAPP-AE