### PR TITLE
Add testid option in page tabs for Cypress

### DIFF
--- a/templates/cms_list.tpl
+++ b/templates/cms_list.tpl
@@ -6,7 +6,7 @@
 				{if $listconfig['haspagemenu']}
 					<ul class="pagemenu list-unstyled">
 					{foreach $listconfig['pagemenu'] as $code=>$pagemenu}
-						<li><a class="{if $pagemenu['active']}active{/if}" href="{$pagemenu['link']}">{$pagemenu['label']}</a>
+						<li><a class="{if $pagemenu['active']}active{/if}" href="{$pagemenu['link']}" {if isset($pagemenu['testid'])}data-testid="{$pagemenu['testid']}"{/if} >{$pagemenu['label']}</a>
 					{/foreach}
 					</ul>
 				{/if}


### PR DESCRIPTION
When using the helper function `addpagemenu` the testid can be passed as an option now.