### PR TITLE
Use data-testid to navigate user tabs in cypress tests

### DIFF
--- a/cypress/integration/2_5_UserManagement.js
+++ b/cypress/integration/2_5_UserManagement.js
@@ -29,11 +29,11 @@ describe('User management', () => {
     }
 
     function getDeactivatedUsersTab(){
-        return cy.get("a").contains("Deactivated");
+        return cy.get("a[data-testid='deactivated']");
     }
 
     function getActiveUsersTab(){
-        return cy.get("a").contains("Active");
+        return cy.get("a[data-testid='active_pending']")
     }
 
     function getReactivateButton(){


### PR DESCRIPTION
**change:** use data-testid to navigate user tabs in cypress tests (supported since Hans added the support in https://github.com/boxwise/dropapp/pull/261)

`data-testid` attributes are added as a part of Lea's PR here -  https://github.com/boxwise/dropapp/pull/270 ...so her PR needs to be merged to make this work)