### PR TITLE
Speed up select all checkbox

### DIFF
--- a/assets/js/magic.js
+++ b/assets/js/magic.js
@@ -147,13 +147,13 @@ $(function() {
             .find(".item-select:visible") //if find ever proves to be too slow, we could replace it with getelementbyclass from vanilla js which works 6 times faster.
             .prop("checked", is_checked)
             .closest("tr")
-            .toggleClass("selected")
+            .toggleClass("selected", is_checked)
             .promise()
             .done(function() { //only trigger the event change of a ".item-select" once
                 parent
                     .find(".item-select:visible:first")
                     .closest("tr")
-                    .toggleClass("selected");
+                    .toggleClass("selected", !is_checked);
                 parent.find(".item-select:visible:first").trigger("change");
             });
     });

--- a/assets/js/magic.js
+++ b/assets/js/magic.js
@@ -141,22 +141,33 @@ $(function() {
 
     // group select
     $(".group-select").change(function() {
-        var parent = $(this).closest(".table-parent");
-        var is_checked = $(this).is(":checked");
+        // Faster way of doing it
+        // var parent = $.makeArray(
+        //     $(".group-select").closest(".table-parent")
+        // )[0];
+        // var is_checked = $(this).is(":checked");
+        // var checkboxes = parent.getElementsByClassName("item-select");
+
+        // for (var checkbox of checkboxes) {
+        //     checkbox.checked = is_checked;
+        // slected style of corresponding row needs to be selected 
+        // }
 
         // old way of doing it
-        // if ($(this).is(":checked")) {
-        //     parent
-        //         .find(".item-select:visible:not(:checked)")
-        //         .prop("checked", true)
-        //         .trigger("change");
-        // } else {
-        //     parent
-        //         .find(".item-select:visible:checked")
-        //         .prop("checked", false)
-        //         .trigger("change");
-        // }
-        $("input.item-select:visible", parent).prop('checked', is_checked).trigger("change");
+        var parent = $(".group-select").closest(".table-parent");
+        if ($(this).is(":checked")) {
+            parent
+                .find(".item-select:visible:not(:checked)")
+                .prop("checked", true)
+                .closest("tr")
+                .toggleClass("selected");
+        } else {
+            parent
+                .find(".item-select:visible:checked")
+                .prop("checked", false)
+                .closest("tr")
+                .toggleClass("selected");
+        }
     });
     // if group-select is checked on load, toggle single-selects
     $(".group-select").trigger("change");
@@ -396,14 +407,14 @@ $(function() {
         $("#submitaction").val(el.val());
     });
 
-    // form submit 
+    // form submit
     $(".form").each(function() {
         var el = $(this);
 
         // Fix for super annoying bug from jQuery validate https://github.com/jquery-validation/jquery-validation/issues/309
         $("<input>")
             .attr({
-                id : "submitaction",
+                id: "submitaction",
                 type: "hidden",
                 name: "__action",
                 value: ""
@@ -612,7 +623,7 @@ $(function() {
 });
 
 $(window).resize(function() {
-    if ($(".nav-aside").length){
+    if ($(".nav-aside").length) {
         if (
             $(window).height() >
             $(".nav-aside ul:first").offset().top + $(".nav-aside").height()
@@ -672,7 +683,7 @@ function initiateList() {
             } else {
                 parent.find(".disable-if").prop("disabled", false);
             }
-            
+
             if (
                 selected.length &&
                 !parent.find(".actions").is(".items-selected")
@@ -685,7 +696,10 @@ function initiateList() {
                 parent.find(".actions").removeClass("items-selected");
             } else if (selected.length > 1) {
                 parent.find(".one-item-only").prop("disabled", true);
-            } else if (selected.length < 2 && parent.find(".disable-if-is-true").length === 0) {
+            } else if (
+                selected.length < 2 &&
+                parent.find(".disable-if-is-true").length === 0
+            ) {
                 parent.find(".one-item-only").prop("disabled", false);
             }
 

--- a/assets/js/magic.js
+++ b/assets/js/magic.js
@@ -142,29 +142,21 @@ $(function() {
     // group select
     $(".group-select").change(function() {
         var parent = $(".group-select").closest(".table-parent");
-        if ($(this).is(":checked")) {
-            parent
-                .find(".item-select:visible:not(:checked)") //if find ever proves to be too slow, we could replace it with getelementbyclass from vanilla js which works 6 times faster.
-                .prop("checked", true)
-                .closest("tr")
-                .toggleClass("selected");
-        } else {
-            parent
-                .find(".item-select:visible:checked")
-                .prop("checked", false)
-                .closest("tr")
-                .toggleClass("selected");
-        }
+        var is_checked = $(this).is(":checked");
+        parent
+            .find(".item-select:visible") //if find ever proves to be too slow, we could replace it with getelementbyclass from vanilla js which works 6 times faster.
+            .prop("checked", is_checked)
+            .closest("tr")
+            .toggleClass("selected")
+            .promise()
+            .done(function() { //only trigger the event change of a ".item-select" once
+                parent
+                    .find(".item-select:visible:first")
+                    .closest("tr")
+                    .toggleClass("selected");
+                parent.find(".item-select:visible:first").trigger("change");
+            });
     });
-    // if group-select is checked on load, toggle single-selects
-    $(".group-select").trigger("change");
-
-    // single select
-
-    // if item selected on load, toggle parent class
-    $(".item-select:checked")
-        .closest("tr")
-        .toggleClass("selected");
 
     // make lists items clickable
     $(document).on("click", ".item-clickable", function(e) {

--- a/assets/js/magic.js
+++ b/assets/js/magic.js
@@ -142,17 +142,21 @@ $(function() {
     // group select
     $(".group-select").change(function() {
         var parent = $(this).closest(".table-parent");
-        if ($(this).is(":checked")) {
-            parent
-                .find(".item-select:visible:not(:checked)")
-                .prop("checked", true)
-                .trigger("change");
-        } else {
-            parent
-                .find(".item-select:visible:checked")
-                .prop("checked", false)
-                .trigger("change");
-        }
+        var is_checked = $(this).is(":checked");
+
+        // old way of doing it
+        // if ($(this).is(":checked")) {
+        //     parent
+        //         .find(".item-select:visible:not(:checked)")
+        //         .prop("checked", true)
+        //         .trigger("change");
+        // } else {
+        //     parent
+        //         .find(".item-select:visible:checked")
+        //         .prop("checked", false)
+        //         .trigger("change");
+        // }
+        $("input.item-select:visible", parent).prop('checked', is_checked).trigger("change");
     });
     // if group-select is checked on load, toggle single-selects
     $(".group-select").trigger("change");

--- a/assets/js/magic.js
+++ b/assets/js/magic.js
@@ -141,23 +141,10 @@ $(function() {
 
     // group select
     $(".group-select").change(function() {
-        // Faster way of doing it
-        // var parent = $.makeArray(
-        //     $(".group-select").closest(".table-parent")
-        // )[0];
-        // var is_checked = $(this).is(":checked");
-        // var checkboxes = parent.getElementsByClassName("item-select");
-
-        // for (var checkbox of checkboxes) {
-        //     checkbox.checked = is_checked;
-        // slected style of corresponding row needs to be selected 
-        // }
-
-        // old way of doing it
         var parent = $(".group-select").closest(".table-parent");
         if ($(this).is(":checked")) {
             parent
-                .find(".item-select:visible:not(:checked)")
+                .find(".item-select:visible:not(:checked)") //if find ever proves to be too slow, we could replace it with getelementbyclass from vanilla js which works 6 times faster.
                 .prop("checked", true)
                 .closest("tr")
                 .toggleClass("selected");


### PR DESCRIPTION
The bottleneck was that every check of every line created an event to change the styling of the row.
This styling change is now called directly without an event.

If we want to speed up further we can replace the jquery lines with Vanilla js.

There are still open problems. The request to the server takes almost 30s to be resolved.

