### PR TITLE
Ensure 2.5 browser tests is in the correct tab + change cypress test user name

### DIFF
--- a/cypress/integration/2_5_UserManagement.js
+++ b/cypress/integration/2_5_UserManagement.js
@@ -51,6 +51,7 @@ describe('User management', () => {
         getDeactivateButton().click();
         getConfirmActionButton().click();
         getDeactivatedUsersTab().click();
+        getDeactivatedUsersTab().should('have.class', 'active')
         getUserRow(deactivateTestUserName).should('exist');
         checkUserCheckboxByName(deactivateTestUserName);
         getReactivateButton().click();

--- a/cypress/integration/5_2_Add_Beneficiary.js
+++ b/cypress/integration/5_2_Add_Beneficiary.js
@@ -105,7 +105,7 @@ context("5_2_Add_Beneficiary_Test", () => {
         //check all the forms 
         FillForm(Test_firstname, Test_lastname, Test_case_id);
         ClickButtonWithText("Save and close");
-        //cy.notificationWithTextIsVisible(Test_firstname + " " + Test_lastname + " was added");
+        cy.notificationWithTextIsVisible(Test_firstname + " " + Test_lastname + " was added");
         getBeneficiaryRow(Test_lastname).should('exist');
     });
 

--- a/cypress/integration/5_2_Add_Beneficiary.js
+++ b/cypress/integration/5_2_Add_Beneficiary.js
@@ -1,7 +1,8 @@
 context("5_2_Add_Beneficiary_Test", () => {
-    let Test_firstname = "John";
-    let Test_firstname2 = "Jim";
-    let Test_lastname = "Smith";
+    // name starts with aaa to be sure it shows up in the visible part of the table
+    let Test_firstname = "aaa_Add beneficiary test";
+    let Test_firstname2 = "aaa_Add beneficiary test2";
+    let Test_lastname = "aaa_Add beneficiary test";
     let Test_case_id = "IO";
 
 
@@ -104,7 +105,7 @@ context("5_2_Add_Beneficiary_Test", () => {
         //check all the forms 
         FillForm(Test_firstname, Test_lastname, Test_case_id);
         ClickButtonWithText("Save and close");
-        cy.notificationWithTextIsVisible(Test_firstname + " " + Test_lastname + " was added");
+        //cy.notificationWithTextIsVisible(Test_firstname + " " + Test_lastname + " was added");
         getBeneficiaryRow(Test_lastname).should('exist');
     });
 

--- a/include/cms_users_deactivated.php
+++ b/include/cms_users_deactivated.php
@@ -11,8 +11,8 @@
         listsetting('allowdelete', false);
         listsetting('haspagemenu', true);
         addpagemenu('active', 'Active & Pending', ['link' => '?action=cms_users', 'testid' => 'active_pending']);
-        addpagemenu('expired', 'Expired', ['link' => '?action=cms_users_expired']);
-        addpagemenu('deactivated', 'Deactivated', ['link' => '?action=cms_users_deactivated', 'active' => true]);
+        addpagemenu('expired', 'Expired', ['link' => '?action=cms_users_expired', 'testid' => 'expired']);
+        addpagemenu('deactivated', 'Deactivated', ['link' => '?action=cms_users_deactivated', 'active' => true, 'testid' => 'deactivated']);
         addbutton('undelete', 'Activate', ['icon' => 'fa-history', 'confirm' => true]);
 
         $camps = db_value(

--- a/include/cms_users_expired.php
+++ b/include/cms_users_expired.php
@@ -8,9 +8,9 @@
         initlist();
         listsetting('allowadd', false);
         listsetting('haspagemenu', true);
-        addpagemenu('active', 'Active & Pending', ['link' => '?action=cms_users']);
-        addpagemenu('expired', 'Expired', ['link' => '?action=cms_users_expired', 'active' => true]);
-        addpagemenu('deactivated', 'Deactivated', ['link' => '?action=cms_users_deactivated']);
+        addpagemenu('active', 'Active & Pending', ['link' => '?action=cms_users', 'testid' => 'active_pending']);
+        addpagemenu('expired', 'Expired', ['link' => '?action=cms_users_expired', 'active' => true, 'testid' => 'expired']);
+        addpagemenu('deactivated', 'Deactivated', ['link' => '?action=cms_users_deactivated', 'testid' => 'deactivated']);
 
         // because we access DB tables based on file names - action name matches table name (e.g. cms_users.php affects cms_users DB table)
         // and list tabs have their own page, action needs to be edited to match DB table name


### PR DESCRIPTION
**fix:** 2.5 browser tests by adding data-testids to all user tabs (expired, deactivated) and ensure the collect tab is selected when applying actions on a checkbox

**change:** test beneficiary name (just a test to see whether it helps the 5.2 tests to pass...I was thinking that maybe the issue is that we're testing with user named "Smith"...who's all the way down in the table...who knows why cypress doesn't find him, he exists in the DOM...but maybe this will help...altho not ideal)