### PR TITLE
Added level to the data-query in locations. This is due to the fact, …

### DIFF
--- a/include/locations.php
+++ b/include/locations.php
@@ -13,7 +13,7 @@
         $cmsmain->assign('title', 'Warehouse Locations');
         listsetting('search', ['sizes.label']);
 
-        $data = getlistdata('SELECT *, (SELECT COUNT(id) FROM stock WHERE location_id = locations.id AND NOT deleted) AS boxcount 
+        $data = getlistdata('SELECT *, (SELECT COUNT(id) FROM stock WHERE location_id = locations.id AND NOT deleted) AS boxcount,0 as level 
             FROM locations 
             WHERE deleted IS NULL 
             AND camp_id = '.$_SESSION['camp']['id']);


### PR DESCRIPTION
…that zortable checks for allowmovefrom and allowmoveto - settings in listsettings, but for locations there are no data-levels