### PR TITLE
check for open class on confirm popup

### DIFF
--- a/cypress/integration/2_7_DeactivatedUsers.js
+++ b/cypress/integration/2_7_DeactivatedUsers.js
@@ -28,6 +28,14 @@ describe("2_7_DeactivatedUsers_Test", () => {
         cy.get(selector).contains(text).should('not.exist');
     }
 
+    function checkClassByTypeAndTestId(type, testId, _class, hasClass) {
+        if (hasClass == true) {
+            cy.get(type + "[data-testid = '" + testId + "']").should("have.class", _class);
+        } else {
+            cy.get(type + "[data-testid = '" + testId + "']").should("not.have.class", _class);
+        }
+    }
+
     function clickOnElement(selector) {
         cy.get(selector).first().click();
     }
@@ -131,9 +139,9 @@ describe("2_7_DeactivatedUsers_Test", () => {
         cy.visit('/?action=cms_users_deactivated');
         checkUserCheckboxByName(DELETED_USER_NAME);
         clickOnElementByTypeAndTestId("button", "reactivate-cms-user");
-        checkForElementByText("h3", ARE_YOU_SURE_POPUP);
+        checkClassByTypeAndTestId("button", "reactivate-cms-user", "open", true);
         clickOnElementByText("a", CANCEL_BUTTON);
-        checkElementDoesNotExistByText("h3", ARE_YOU_SURE_POPUP);
+        checkClassByTypeAndTestId("button", "reactivate-cms-user", "open", false);
     });
 
 });

--- a/cypress/integration/2_8_ExpiredUsers.js
+++ b/cypress/integration/2_8_ExpiredUsers.js
@@ -39,6 +39,14 @@ describe("2_8_ExpiredUsers_Test", () => {
         cy.get(type + "[data-testid = '" + testId + "']").should("be.visible");
     }
 
+    function checkClassByTypeAndTestId(type, testId, _class, hasClass) {
+        if (hasClass == true) {
+            cy.get(type + "[data-testid = '" + testId + "']").should("have.class", _class);
+        } else {
+            cy.get(type + "[data-testid = '" + testId + "']").should("not.have.class", _class);
+        }
+    }
+
     function clickOnElementByTypeAndTestId(type, testId) {
         cy.get(type + "[data-testid = '" + testId + "']").click();
     }
@@ -145,7 +153,7 @@ describe("2_8_ExpiredUsers_Test", () => {
         checkUserCheckboxByName(EXPIRED_COORDINATOR_NAME);
         clickOnElementByTypeAndTestId("button", "list-delete-button");
         clickOnElementByText("a", CANCEL_BUTTON);
-        checkElementDoesNotExistByText("h3", ARE_YOU_SURE_POPUP);
+        checkClassByTypeAndTestId("button", "list-delete-button", "open", false);
     });
 
 });


### PR DESCRIPTION
Instead of checking for the "Are you Sure?" popup in the DOM, check for the "open" class in the "Activate" button.