### PR TITLE
More reliable feature tests maybe

### DIFF
--- a/cypress/integration/2_7_DeactivatedUsers.js
+++ b/cypress/integration/2_7_DeactivatedUsers.js
@@ -11,11 +11,13 @@ const ARE_YOU_SURE_POPUP = "Are you sure?";
 const CANCEL_BUTTON = "Cancel";
 const OK_BUTTON = "OK";
 const ITEM_RECOVERED = "Item recovered";
+const ITEM_DELETED = "Item deleted";
 const DEACTIVATE_BUTTON = "Deactivate";
 
 describe("2_7_DeactivatedUsers_Test", () => {
 
     beforeEach(function () {
+        cy.setupAjaxActionHook();
         cy.loginAsAdmin();
         cy.visit('/?action=cms_users_deactivated');
     });
@@ -68,11 +70,6 @@ describe("2_7_DeactivatedUsers_Test", () => {
         });
     }
 
-    function watchRequest(requestType, route, alias) {
-        // watch a request and give it an alias in order to wait/check the response later
-        cy.server().route(requestType, route).as(alias);
-    }
- 
     it("2_7 Check for list elements in Deactivated tab", () => {
         checkForElementByTypeAndTestId("input", "select_all");
         checkForElementByText("p", DELETED_COORDINATOR_NAME);
@@ -115,14 +112,8 @@ describe("2_7_DeactivatedUsers_Test", () => {
         checkUserCheckboxByName(DELETED_USER_NAME);
         clickOnElementByTypeAndTestId("button", "reactivate-cms-user");
         checkForElementByText("h3", ARE_YOU_SURE_POPUP);
-
-        watchRequest("POST", "/?action=cms_users_deactivated", "deactivated");
         clickOnElementByText("a", OK_BUTTON);
-
-        // wait for "deactivated" request to complete and then check response body message
-        cy.wait("@deactivated").then(xhr => {
-            expect(xhr.response.body.message).to.equal(ITEM_RECOVERED);
-        });
+        cy.waitForAjaxAction(ITEM_RECOVERED);
         
         checkForElementByText("span", ITEM_RECOVERED);
         checkElementDoesNotExistByText("p", DELETED_USER_NAME);
@@ -134,6 +125,7 @@ describe("2_7_DeactivatedUsers_Test", () => {
         checkUserCheckboxByName(DELETED_USER_NAME);
         clickOnElementByTypeAndTestId("button", "list-delete-button");
         clickOnElementByText("div.popover-content a", DEACTIVATE_BUTTON);
+        cy.waitForAjaxAction(ITEM_DELETED);
        
         // test cancel button
         cy.visit('/?action=cms_users_deactivated');

--- a/cypress/integration/2_8_ExpiredUsers.js
+++ b/cypress/integration/2_8_ExpiredUsers.js
@@ -15,6 +15,7 @@ const EXPIRED_COORDINATOR_VALID_TO = "28 May 2017";
 describe("2_8_ExpiredUsers_Test", () => {
 
     beforeEach(function () {
+        cy.setupAjaxActionHook();
         cy.loginAsAdmin();
         cy.visit('/?action=cms_users_expired');
     });
@@ -65,11 +66,6 @@ describe("2_8_ExpiredUsers_Test", () => {
         cy.get('tbody tr').each(($tr) => {
             expect($tr).to.have.class('selected');
         });
-    }
-
-    function watchRequest(requestType, route, alias) {
-        // watch a request and give it an alias in order to wait/check the response later
-        cy.server().route(requestType, route).as(alias);
     }
  
     it("2_8 Check for list elements in Expired tab", () => {
@@ -124,28 +120,15 @@ describe("2_8_ExpiredUsers_Test", () => {
         checkUserCheckboxByName(EXPIRED_COORDINATOR_NAME);
         clickOnElementByTypeAndTestId("button", "list-delete-button");
         checkForElementByText("h3", ARE_YOU_SURE_POPUP);
-
-        watchRequest("POST", "/?action=cms_users_expired", "expired");
         clickOnElementByText("div.popover-content a", DEACTIVATE_BUTTON);
-
-        // wait for "expired" request to complete and then check response body message
-        cy.wait("@expired").then(xhr => {
-            expect(xhr.response.body.message).to.equal(ITEM_DELETED);
-        });
+        cy.waitForAjaxAction(ITEM_DELETED);
 
         cy.visit('/?action=cms_users_deactivated');
         checkForElementByText("p", EXPIRED_COORDINATOR_NAME);
         checkUserCheckboxByName(EXPIRED_COORDINATOR_NAME);
         clickOnElementByTypeAndTestId("button", "reactivate-cms-user");
-
-        watchRequest("POST", "/?action=cms_users_deactivated", "deactivated");
-
         clickOnElementByText("a", OK_BUTTON);
-
-        // wait for "deactivated" request to complete and then check response body message
-        cy.wait("@deactivated").then(xhr => {
-            expect(xhr.response.body.message).to.equal(ITEM_RECOVERED);
-        });
+        cy.waitForAjaxAction(ITEM_RECOVERED);
 
         // test cancel button
         cy.visit('/?action=cms_users_expired');

--- a/cypress/integration/5_3_Manage_Beneficiaries.js
+++ b/cypress/integration/5_3_Manage_Beneficiaries.js
@@ -66,6 +66,7 @@ describe('Manage beneficiaries', () => {
     }
 
     function getBeneficiaryRow(familyName){
+        cy.get('table').should('have.class', 'initialized');
         return cy.get('tr').contains(familyName);
     }
 
@@ -77,7 +78,7 @@ describe('Manage beneficiaries', () => {
 
     function checkBeneficiaryCheckboxByName(familyName){
         getBeneficiaryRow(familyName).parent().parent().parent().within(() => {
-            cy.get("input[type='checkbox']").check();
+            cy.get("input[type='checkbox']").scrollIntoView().check({force: true});
         });
     }
 

--- a/cypress/support/ajax.js
+++ b/cypress/support/ajax.js
@@ -1,0 +1,24 @@
+
+Cypress.Commands.add("setupAjaxActionHook", () => {
+    // set up a hook to listen for POSTs to the action url
+    cy.server();
+    // TODO - could this be a wildcard ajax action to wait for?
+    cy.route("POST", "?action=**").as('ajaxPostAction');
+});
+
+Cypress.Commands.add("waitForAjaxAction", (expectedResponse) => {
+    // wait for the expected response
+    cy.wait('@ajaxPostAction').then(xhr => {
+        expect(xhr.response.body.success).to.equal(true);
+        expect(xhr.response.body.message).to.equal(expectedResponse);
+
+        if (xhr.response.body.redirect) {
+            cy.log('Ajax response will trigger redirect');
+            // may need to call cy.reload() here for cypress to deal
+            // with the client-side redirect randomly reloading the page
+            // but so far doesn't seem to be a problem
+            // possibly because in these scenarios we're immediately
+            // navigating elsewhere
+        }
+    });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -5,9 +5,11 @@ import './select2-interaction-methods'
 import './dom-elements-interaction'
 import './database'
 import './box-helper-functions'
+import './ajax'
 
 Cypress.on('uncaught:exception', (err, runnable) => {
     // returning false here prevents Cypress from
     // failing the test
     return false;
-})
+});
+


### PR DESCRIPTION
Further adopted the 'route hook' approach that @cohenlea introduced in https://github.com/boxwise/dropapp/pull/279, and consolidated a little. 

The DropApp has strange behaviour where a button can trigger an AJAX call, but then subsequently trigger a reload of the same page. This messes up Cypress's reliablity because it can't tell when the DOM will reload. This change forces us to wait for the AJAX response to complete, and at least on my testing seems to be more reliable.

Also attempted to fix some visibility issues when checking boxes in grids - suspect this is intermittent as the number of items grows.
