### PR TITLE
Fix datesort issue for sales reports

### DIFF
--- a/assets/js/magic.js
+++ b/assets/js/magic.js
@@ -623,6 +623,7 @@ function initiateList() {
                 var el = $(this);
                 var options = $.extend(
                     {
+                        dateFormat : "ddmmyyyy", // set the default date format
                         widgets: ["stickyHeaders", "saveSort"],
                         widgetOptions: {
                             stickyHeaders_attachTo: el.closest(

--- a/include/sales_list.php
+++ b/include/sales_list.php
@@ -90,7 +90,7 @@
                     $data[$key]['people'] = db_value('SELECT COUNT(DISTINCT(p.id)) FROM people AS p, transactions AS t WHERE (p.id = t.people_id OR p.parent_id = t.people_id) AND t.transaction_date >= "'.$date.' 00:00" AND t.transaction_date <= "'.$date.' 23:59" AND t.product_id > 0 AND t.people_id > 0 AND camp_id = :campid', ['campid' => $_SESSION['camp']['id']]);
                     $totalvisitors += $data[$key]['people'];
                 }
-                addcolumn('text', 'Sales', 'salesdate');
+                addcolumn('text', 'Sales', 'salesdate', 'sorter-shortDate dateFormat-ddmmyyyy');    //tablesorter works with dates only if header has a proper class assigned - https://mottie.github.io/tablesorter/docs/example-option-date-format.html
                 addcolumn('text', 'Amount', 'aantal');
                 addcolumn('text', 'Beneficiaries', 'people');
                 $cmsmain->assign('listfooter', ['Total sales', $totalsales.' items ('.$totaldrops.' '.$_SESSION['camp']['currencyname'].')', $totalvisitors]);

--- a/include/sales_list.php
+++ b/include/sales_list.php
@@ -90,7 +90,7 @@
                     $data[$key]['people'] = db_value('SELECT COUNT(DISTINCT(p.id)) FROM people AS p, transactions AS t WHERE (p.id = t.people_id OR p.parent_id = t.people_id) AND t.transaction_date >= "'.$date.' 00:00" AND t.transaction_date <= "'.$date.' 23:59" AND t.product_id > 0 AND t.people_id > 0 AND camp_id = :campid', ['campid' => $_SESSION['camp']['id']]);
                     $totalvisitors += $data[$key]['people'];
                 }
-                addcolumn('text', 'Sales', 'salesdate', 'sorter-shortDate dateFormat-ddmmyyyy');    //tablesorter works with dates only if header has a proper class assigned - https://mottie.github.io/tablesorter/docs/example-option-date-format.html
+                addcolumn('text', 'Sales', 'salesdate', ['headerClass' => 'sorter-shortDate dateFormat-ddmmyyyy']);    //tablesorter works with dates only if header has a proper class assigned - https://mottie.github.io/tablesorter/docs/example-option-date-format.html
                 addcolumn('text', 'Amount', 'aantal');
                 addcolumn('text', 'Beneficiaries', 'people');
                 $cmsmain->assign('listfooter', ['Total sales', $totalsales.' items ('.$totaldrops.' '.$_SESSION['camp']['currencyname'].')', $totalvisitors]);

--- a/library/lib/list.php
+++ b/library/lib/list.php
@@ -609,11 +609,11 @@ function query_insert($str, $pos, $insert)
     return substr($str, 0, $pos).$insert.' '.substr($str, $pos);
 }
 
-function addcolumn($type, $label = false, $field = false, $headerClass = false, $array = [])
+function addcolumn($type, $label = false, $field = false, $array = [])
 {
     global $listdata, $data;
 
-    $listdata[$field] = ['type' => $type, 'label' => $label, 'field' => $field, 'headerClass' => $headerClass];
+    $listdata[$field] = ['type' => $type, 'label' => $label, 'field' => $field];
 
     foreach ($array as $key => $value) {
         $listdata[$field][$key] = $value;

--- a/library/lib/list.php
+++ b/library/lib/list.php
@@ -609,11 +609,11 @@ function query_insert($str, $pos, $insert)
     return substr($str, 0, $pos).$insert.' '.substr($str, $pos);
 }
 
-function addcolumn($type, $label = false, $field = false, $array = [])
+function addcolumn($type, $label = false, $field = false, $headerClass = false, $array = [])
 {
     global $listdata, $data;
 
-    $listdata[$field] = ['type' => $type, 'label' => $label, 'field' => $field];
+    $listdata[$field] = ['type' => $type, 'label' => $label, 'field' => $field, 'headerClass' => $headerClass];
 
     foreach ($array as $key => $value) {
         $listdata[$field][$key] = $value;

--- a/templates/cms_list.tpl
+++ b/templates/cms_list.tpl
@@ -126,7 +126,7 @@
 				  	<thead>
 					  	<tr>
 						{foreach $listdata as $key=>$column}
-					  		<th><div {if $column['width']}style="width:{$column['width']}px;"{/if}>{$column['label'] nofilter}</div></th>
+					  		<th {if $column['headerClass']}class="{$column['headerClass']}"{/if}><div {if $column['width']}style="width:{$column['width']}px;"{/if}>{$column['label'] nofilter}</div></th>
 						{/foreach}
 					  	</tr>
 						<tr class="sorter-false firstline">


### PR DESCRIPTION
**fix**: sorting by date in lists using tablesorter
          (https://mottie.github.io/tablesorter/docs/example-option-date-format.html)

**add**: list template can now take a parameter to define class for <th> tag