### PR TITLE
Simplify users screen database queries

### DIFF
--- a/include/cms_users.php
+++ b/include/cms_users.php
@@ -18,24 +18,14 @@
             addbutton('loginasuser', $translate['cms_users_loginas'], ['icon' => 'fa-users', 'confirm' => true, 'oneitemonly' => true, 'disableif' => true]);
         }
 
-        $camps = db_value(
-            '
-			SELECT GROUP_CONCAT(c.id) 
-			FROM cms_usergroups_camps AS uc, camps AS c 
-			WHERE (NOT c.deleted OR c.deleted IS NULL) AND uc.camp_id = c.id AND uc.cms_usergroups_id = :usergroup',
-            ['usergroup' => $_SESSION['usergroup']['id']]
-        );
-
         // Execution of queries in cms_users_page.php
         $cms_users_lower_level_query = '
 			SELECT u.*, NOT u.is_admin AS visible, g.label AS usergroup, 0 AS preventdelete, 0 as disableifistrue
 			FROM cms_users AS u
 			LEFT OUTER JOIN cms_usergroups AS g ON g.id = u.cms_usergroups_id 
-			LEFT OUTER JOIN cms_usergroups_camps AS uc ON uc.cms_usergroups_id = g.id
 			LEFT OUTER JOIN cms_usergroups_levels AS l ON l.id = g.userlevel
 			WHERE 
 				'.(!$_SESSION['user']['is_admin'] ? 'l.level <'.intval($_SESSION['usergroup']['userlevel']).' AND ' : '').'
-				'.($_SESSION['user']['is_admin'] ? '' : '(uc.camp_id IN ('.($camps ? $camps : 0).')) AND ').' 
 				(g.organisation_id = '.intval($_SESSION['organisation']['id']).($_SESSION['user']['is_admin'] ? ' OR u.is_admin' : '').')
 				AND (NOT g.deleted OR g.deleted IS NULL) AND (NOT u.deleted OR u.deleted IS NULL)
 				AND NOT (u.valid_lastday < CURDATE() AND UNIX_TIMESTAMP(u.valid_lastday) != 0) 

--- a/include/cms_users_deactivated.php
+++ b/include/cms_users_deactivated.php
@@ -15,23 +15,13 @@
         addpagemenu('deactivated', 'Deactivated', ['link' => '?action=cms_users_deactivated', 'active' => true, 'testid' => 'deactivated']);
         addbutton('undelete', 'Activate', ['icon' => 'fa-history', 'confirm' => true, 'testid' => 'reactivate-cms-user']);
 
-        $camps = db_value(
-            '
-			SELECT GROUP_CONCAT(c.id) 
-			FROM cms_usergroups_camps AS uc, camps AS c 
-			WHERE (NOT c.deleted OR c.deleted IS NULL) AND uc.camp_id = c.id AND uc.cms_usergroups_id = :usergroup',
-            ['usergroup' => $_SESSION['usergroup']['id']]
-        );
-
         // Execution of queries in cms_users_page.php
         $cms_users_lower_level_query = 'SELECT u.id, u.naam, SUBSTR(u.email, 1, LENGTH(u.email)-LENGTH(".deleted.")-LENGTH(u.id)) AS email, u.valid_firstday, u.valid_lastday, NOT u.is_admin AS visible, g.label AS usergroup, 0 AS preventdelete, 1 as disableifistrue
 			FROM cms_users AS u
 			LEFT OUTER JOIN cms_usergroups AS g ON g.id = u.cms_usergroups_id 
-			LEFT OUTER JOIN cms_usergroups_camps AS uc ON uc.cms_usergroups_id = g.id
 			LEFT OUTER JOIN cms_usergroups_levels AS l ON l.id = g.userlevel
 			WHERE 
 				'.(!$_SESSION['user']['is_admin'] ? 'l.level <'.intval($_SESSION['usergroup']['userlevel']).' AND ' : '').'
-				'.($_SESSION['user']['is_admin'] ? '' : '(uc.camp_id IN ('.($camps ? $camps : 0).')) AND ').' 
 				(g.organisation_id = '.intval($_SESSION['organisation']['id']).($_SESSION['user']['is_admin'] ? ' OR u.is_admin' : '').')
 				AND (NOT g.deleted OR g.deleted IS NULL)
 				AND u.deleted

--- a/include/cms_users_expired.php
+++ b/include/cms_users_expired.php
@@ -20,23 +20,13 @@
         $editedaction = str_ireplace($replaceArray, '', $action);
         listsetting('edit', $editedaction.'_edit');
 
-        $camps = db_value(
-            '
-			SELECT GROUP_CONCAT(c.id) 
-			FROM cms_usergroups_camps AS uc, camps AS c 
-			WHERE (NOT c.deleted OR c.deleted IS NULL) AND uc.camp_id = c.id AND uc.cms_usergroups_id = :usergroup',
-            ['usergroup' => $_SESSION['usergroup']['id']]
-        );
-
         // Execution of queries in cms_users_page.php
         $cms_users_lower_level_query = 'SELECT u.*, NOT u.is_admin AS visible, g.label AS usergroup, 0 AS preventdelete, 1 as disableifistrue
 			FROM cms_users AS u
 			LEFT OUTER JOIN cms_usergroups AS g ON g.id = u.cms_usergroups_id 
-			LEFT OUTER JOIN cms_usergroups_camps AS uc ON uc.cms_usergroups_id = g.id
 			LEFT OUTER JOIN cms_usergroups_levels AS l ON l.id = g.userlevel
 			WHERE 
 				'.(!$_SESSION['user']['is_admin'] ? 'l.level <'.intval($_SESSION['usergroup']['userlevel']).' AND ' : '').'
-				'.($_SESSION['user']['is_admin'] ? '' : '(uc.camp_id IN ('.($camps ? $camps : 0).')) AND ').' 
 				(g.organisation_id = '.intval($_SESSION['organisation']['id']).($_SESSION['user']['is_admin'] ? ' OR u.is_admin' : '').')
 				AND (NOT g.deleted OR g.deleted IS NULL)
                 AND u.valid_lastday < CURDATE() 


### PR DESCRIPTION
 I’m working on the [Auth0 integration in the old PHP app](https://github.com/boxwise/dropapp/pull/414). Because users can be managed from Auth0, and also from the old PHP app - and ultimately from the new app too - I’m looking at just using Auth0 as the source of truth - otherwise we'll get into messy 2/3-way syncing to keep everything up to date.

The current ‘users’ screen in the PHP app filters which users are visible based on the current users permissions, which makes sense. This should be do-able in Auth0 too - https://auth0.com/docs/extensions/delegated-administration-extension/delegated-administration-hooks/delegated-administration-filter-hook#hook-contract.  - which would then mean both the PHP app and the new python app can also just call the Auth0 getUsers API method too, without having to implement filtering either.

However, the current logic for displaying this view is super complicated, seemingly very redundant, and duplicated across 6 different SQL queries for 3 slightly different screens (active, inactive and deleted users). Therefore, I'm hoping to simplify this.

Given there is no testing here, and I'm not clear on what the intention is in the first place,  I may well be missing something obvious that means I can't do these changes.

I've got a few steps to this, but @HaGuesto if you have any thoughts on the initial simplification - and what, if anything, I'm missing, that would be fab! @hhawilo :wave: just tagging as you might be interested at a high level (more ^^ than the code here itself)