### PR TITLE
Upgrade to mysql version 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   db_mysql:
-    image: mysql/mysql-server:5.7
+    image: mysql/mysql-server:8.0
     command: --default-authentication-plugin=mysql_native_password --lower_case_table_names=1
     environment:
       MYSQL_ROOT_PASSWORD: dropapp_root


### PR DESCRIPTION
This PR contains upgrade of mysql version for 5.7 to 8. Changing the version triggers an update in mysql and upgrades the schema automatically, so it's recommended that a reliable backup of the database be made before updating in production. The following is done:

- [X] Mysqlsh upgrade checker was run and found no serious incompatibility in our schema
- [X] The version of MySQL in docker-compose.yml changed from 5.7 to 8.0; the containers take longer to run, as it has to convert the schema over (if the containers have been run and the data is available in local storage).
- [X] Cypress tests run locally with no issues encountered 

The following is need to be considered:

- [X] MySQL 8 changed the default authentication plugin from 'mysql_native_password' to 'caching_sha2_password', which offers a safer password hash, since we do not need the password field in cms_users anymore, It is not necessary to convert current password to new hash; also, in docker compose, there is a setting that already keeps authentication plugin to 'mysql_native_password'. 
- [X] Additionally, as of 5.7.8 version, MySQL no longer supports zero date, datetime, or timestamp values by default. Therefore, as we set value of 'date_of_signature' field in the 'people' table and 'deleted' field in 'stock' table to zero '0000-00-00 00:00:00', we may need overrides mysql_mode and remove NO_ZERO_DATE which is included by default.