### PR TITLE
Enable zero count for items on the mobile ui

### DIFF
--- a/templates/mobile_newbox.tpl
+++ b/templates/mobile_newbox.tpl
@@ -39,7 +39,7 @@
 				{/foreach}
 			</select>
 		</div>
-		<div class="form-group"><input type="number" name="items" pattern="\d*" placeholder="Number of items" value="{$box['items']}" class="form-control" min="1" data-testid="items_count" required></div>
+		<div class="form-group"><input type="number" name="items" pattern="\d*" placeholder="Number of items" value="{$box['items']}" class="form-control" min="0" data-testid="items_count" required></div>
 		<div class="form-group"><input type="text" name="comments" placeholder="Comments for this box" value="{$box['comments']}" data-testid="comments" class="form-control"></div>
 		<input type="submit" name="submitbutton" class="btn" value="Save" data-testid="submit_new_box">
 	</form>


### PR DESCRIPTION
This PR is minor change in javascript validation to [enable zero count for items](https://trello.com/c/Y5kV3VTg) on the mobile UI.