### PR TITLE
Fixes reactivating dependent without family head

### DIFF
--- a/include/people_deactivated.php
+++ b/include/people_deactivated.php
@@ -117,7 +117,6 @@ use OpenCensus\Trace\Tracer;
                 }
                 if (empty($errorMessage)) {
                     list($success, $message, $redirect) = listUnDelete($table, $finalIds);
-                    $redirect = true;
                 } else {
                     $success = false;
                     $redirect = false;

--- a/include/people_deactivated.php
+++ b/include/people_deactivated.php
@@ -72,7 +72,7 @@ use OpenCensus\Trace\Tracer;
 
                 foreach ($data as $key => $value) {
                     if ('1' == $data[$key]['has_not_active_parent']) {
-                        $data[$key]['icons'] .= sprintf('<i class="fa fa-exclamation-triangle warning tooltip-this" title="%s\'s family head (%s) is not active"></i>', $data[$key]['firstname'], $data[$key]['family_head']);
+                        $data[$key]['icons'] .= sprintf('<i class="fa fa-exclamation-triangle warning tooltip-this" title="To reactivate %s please make sure you reactivate their family head first."></i>', $data[$key]['firstname'].' '.$data[$key]['lastname']);
                     }
                 }
             }
@@ -106,10 +106,10 @@ use OpenCensus\Trace\Tracer;
                 foreach ($ids as $id) {
                     $person = db_row('SELECT concat(firstname," ",lastname) as fullname, parent_id FROM people WHERE id = :id', ['id' => $id]);
                     $parentId = $person['parent_id'];
-                    $hasActiveParent = ($parentId) ? db_value('SELECT (NOT deleted OR deleted IS NULL) as parant FROM people WHERE id = :id', ['id' => $parentId]) : null;
-
+                    $parent = ($parentId) ? db_row('SELECT (NOT deleted OR deleted IS NULL) as has_active_parent, concat(firstname," ",lastname) as family_head  FROM people WHERE id = :id', ['id' => $parentId]) : null;
+                    $hasActiveParent = ($parent['has_active_parent']) ?? false;
                     if ($parentId && !in_array($parentId, $ids) && !boolval($hasActiveParent)) {
-                        $errorMessage .= $person['fullname'].' does not have an active family head.<br>';
+                        $errorMessage .= sprintf('Family head %s must be active before %s can be reactivated.<br>', $parent['family_head'], $person['fullname']);
 
                         continue;
                     }

--- a/include/people_deactivated.php
+++ b/include/people_deactivated.php
@@ -73,7 +73,17 @@
                 break;
             case 'undelete':
                 $ids = explode(',', $_POST['ids']);
-                list($success, $message, $redirect) = listUnDelete($table, $ids);
+                $finalIds = [];
+                foreach ($ids as $id) {
+                    $parentId = db_value('SELECT parent_id FROM people WHERE id = :id', ['id' => $id]);
+                    $hasActiveParent = ($parentId) ? db_value('SELECT (NOT deleted OR deleted IS NULL) as parant FROM people WHERE id = :id', ['id' => $parentId]) : null;
+
+                    if ($parentId && !in_array($parentId, $ids) && !boolval($hasActiveParent)) {
+                        continue;
+                    }
+                    array_push($finalIds, $id);
+                }
+                list($success, $message, $redirect) = listUnDelete($table, $finalIds);
 
                 break;
             case 'realdelete':

--- a/include/people_deactivated.php
+++ b/include/people_deactivated.php
@@ -72,7 +72,7 @@ use OpenCensus\Trace\Tracer;
 
                 foreach ($data as $key => $value) {
                     if ('1' == $data[$key]['has_not_active_parent']) {
-                        $data[$key]['icons'] .= sprintf('<i class="fa fa-exclamation-triangle warning tooltip-this" title="To reactivate %s please make sure you reactivate their family head first."></i>', $data[$key]['firstname'].' '.$data[$key]['lastname']);
+                        $data[$key]['icons'] .= sprintf('<i class="fa fa-exclamation-triangle warning tooltip-this" title="To reactivate %s please make sure you reactivate their family head (%s) first."></i>', $data[$key]['firstname'].' '.$data[$key]['lastname'], $data[$key]['family_head']);
                     }
                 }
             }

--- a/include/people_deactivated.php
+++ b/include/people_deactivated.php
@@ -55,6 +55,7 @@ use OpenCensus\Trace\Tracer;
 
         addcolumn('text', 'Surname', 'lastname');
         addcolumn('text', 'Firstname', 'firstname');
+        addcolumn('text', 'Head of Family', 'family_head');
         addcolumn('text', 'Gender', 'gender2');
         addcolumn('text', 'Age', 'age');
         addcolumn('text', $_SESSION['camp']['familyidentifier'], 'container');
@@ -83,22 +84,6 @@ use OpenCensus\Trace\Tracer;
         $cmsmain->assign('include', 'cms_list.tpl');
     } else {
         switch ($_POST['do']) {
-            case 'give':
-                $ids = ($_POST['ids']);
-                $success = true;
-                $redirect = '?action=give&ids='.$ids;
-
-                break;
-            case 'move':
-                $ids = json_decode($_POST['ids']);
-                list($success, $message, $redirect, $aftermove) = listMove($table, $ids, true, 'correctdrops');
-
-                break;
-            case 'delete':
-                $ids = explode(',', $_POST['ids']);
-                list($success, $message, $redirect) = listDelete($table, $ids);
-
-                break;
             case 'undelete':
                 $ids = explode(',', $_POST['ids']);
                 $finalIds = [];
@@ -116,7 +101,8 @@ use OpenCensus\Trace\Tracer;
                     array_push($finalIds, $id);
                 }
                 if (empty($errorMessage)) {
-                    list($success, $message, $redirect) = listUnDelete($table, $finalIds);
+                    list($success, $message, $redirect) = listUnDelete($table, $finalIds, false, true);
+                    $redirect = true;
                 } else {
                     $success = false;
                     $redirect = false;
@@ -133,21 +119,6 @@ use OpenCensus\Trace\Tracer;
                     db_query('UPDATE people SET parent_id = NULL WHERE parent_id = :id AND deleted', ['id' => $id]);
                 }
                 list($success, $message, $redirect) = listRealDelete($table, $ids);
-
-                break;
-            case 'copy':
-                $ids = explode(',', $_POST['ids']);
-                list($success, $message, $redirect) = listCopy($table, $ids, 'name');
-
-                break;
-            case 'hide':
-                $ids = explode(',', $_POST['ids']);
-                list($success, $message, $redirect) = listShowHide($table, $ids, 0);
-
-                break;
-            case 'show':
-                $ids = explode(',', $_POST['ids']);
-                list($success, $message, $redirect) = listShowHide($table, $ids, 1);
 
                 break;
         }

--- a/library/lib/list.php
+++ b/library/lib/list.php
@@ -169,13 +169,17 @@ function listDeleteAction($table, $id, $count = 0, $recursive = false)
     return $count;
 }
 
-function listUndelete($table, $ids, $uri = false)
+function listUndelete($table, $ids, $uri = false, $overwritehastree = false)
 {
     global $translate, $action;
 
     $hasDeletefield = db_fieldexists($table, 'deleted');
     $hasPrevent = db_fieldexists($table, 'preventdelete');
-    $hasTree = db_fieldexists($table, 'parent_id');
+    if ($overwritehastree) {
+        $hastree = false;
+    } else {
+        $hasTree = db_fieldexists($table, 'parent_id');
+    }
 
     foreach ($ids as $id) {
         if ($hasDeletefield) {


### PR DESCRIPTION
This PR fixes a reported issue, which let the user reactivate the dependent without the active family head.

The changes are as follows:

- Update people_deactivated.php to verify that the selected beneficiaries have a family head; if they do not, they are prevented from being reactivated
- Run the Cypress test for beneficiary management and all the test cases passed