### PR TITLE
Performance Tuning of Beneficiary Page Queries

### DIFF
--- a/library/lib/tools.php
+++ b/library/lib/tools.php
@@ -294,6 +294,25 @@ function simpleSaveChangeHistory($table, $record, $changes, $from = [], $to = []
     db_query('INSERT INTO history (tablename, record_id, changes, user_id, ip, changedate, from_int, from_float, to_int, to_float) VALUES (:table,:id,:change,:user_id,:ip,NOW(), :from_int, :from_float, :to_int, :to_float)', ['table' => $table, 'id' => $record, 'change' => $changes, 'user_id' => $_SESSION['user']['id'], 'ip' => $_SERVER['REMOTE_ADDR'], 'from_int' => $from['int'], 'from_float' => $from['float'], 'to_int' => $to['int'], 'to_float' => $to['float']]);
 }
 
+function simpleBulkSaveChangeHistory($table, $records, $changes, $from = [], $to = [])
+{
+    //from and to variable must be arrays with entry 'int' or 'float'
+    if (!db_tableexists('history')) {
+        return;
+    }
+    $query = '';
+    $params = [];
+
+    for ($i = 0; $i < sizeof($records); ++$i) {
+        $query .= "(:table{$i},:id{$i},:change{$i},:user_id{$i},:ip{$i},NOW(), :from_int{$i}, :from_float{$i}, :to_int{$i}, :to_float{$i})";
+        $params = array_merge($params, ['table'.$i => $table, 'id'.$i => $records[$i], 'change'.$i => $changes, 'user_id'.$i => $_SESSION['user']['id'], 'ip'.$i => $_SERVER['REMOTE_ADDR'], 'from_int'.$i => $from['int'], 'from_float'.$i => $from['float'], 'to_int'.$i => $to['int'], 'to_float'.$i => $to['float']]);
+        if ($i !== sizeof($records) - 1) {
+            $query .= ',';
+        }
+    }
+    db_query("INSERT INTO history (tablename, record_id, changes, user_id, ip, changedate, from_int, from_float, to_int, to_float) VALUES {$query}", $params);
+}
+
 function displayDate($datum, $time = false, $long = false)
 {
     global $_txt;

--- a/library/lib/tools.php
+++ b/library/lib/tools.php
@@ -310,7 +310,9 @@ function simpleBulkSaveChangeHistory($table, $records, $changes, $from = [], $to
             $query .= ',';
         }
     }
-    db_query("INSERT INTO history (tablename, record_id, changes, user_id, ip, changedate, from_int, from_float, to_int, to_float) VALUES {$query}", $params);
+    if (strlen($query) > 0) {
+        db_query("INSERT INTO history (tablename, record_id, changes, user_id, ip, changedate, from_int, from_float, to_int, to_float) VALUES {$query}", $params);
+    }
 }
 
 function displayDate($datum, $time = false, $long = false)


### PR DESCRIPTION
This PR improved the speed of the beneficiaries page operations by using bulk inserts and adding a transactions block over the multiple update and delete statements:

- optimised queries to add and remove `tags` (adding tags query tested for 500 records and result speed improved from 3.2 seconds to 0.039 seconds using bulk inserts; removing tags query tested for 500 records and result speed improved from 2.15 seconds to 0.6 seconds using transaction) block and removing extra select)
- optimised query for the `touch` feature (Query speed checked for 500 records and speed enhanced from 6.2 seconds to 0.54 seconds using  transaction blocks over UPDATE statements and bulk inserts)
- added new method for bulk inserting changes history (`simpleBulkSaveChangeHistory`)
- added transaction block over multiple updates inside the `detached`, `merge`, `realdelete`,  `undelete` actions and also `correctdrops` method optimized by transaction block over update queries
- `bulkcorrectdrops` method created to apply the bulk inserts
- added `listBulkRealDelete` and `listBulkMove` to the list.php
- added `listBulkUndelete` and `listBulkUnDeleteAction` to the list.php