### PR TITLE
Configure dispatch URL for api-staging service

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -26,6 +26,8 @@ dispatch:
   service: v2-staging
 - url: "staging.boxtribute.org/v2*"
   service: v2-staging
+- url: "api-staging.boxtribute.org/*"
+  service: api-staging
 ## Demo
 - url: "demo.boxwise.co/v2*"
   service: v2-demo


### PR DESCRIPTION
Recap for my understanding:
1. When this PR is merged, the URL `api-staging.boxtribute.org` will be online. But calling it will probably give an empty page (or a 404?)
1. In the `boxtribute` repo, I will create a dedicated `app-api-staging.yaml` file to configure the new service `api-staging` with a single handler
1. Also I'll have to extend `.circleci/config.yml` there to actually deploy to that service

Is that correct?
