### PR TITLE
Add dispatchers for api-demo and -production services

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -33,8 +33,12 @@ dispatch:
   service: v2-demo
 - url: "demo.boxtribute.org/v2*"
   service: v2-demo
+- url: "api-demo.boxtribute.org/*"
+  service: api-demo
 ## Production
 - url: "app.boxwise.co/v2*"
   service: v2-production
 - url: "app.boxtribute.org/v2*"
   service: v2-production
+- url: "api.boxtribute.org/*"
+  service: api-production


### PR DESCRIPTION
In combination with boxwise/boxtribute#170. All services should be deployed there first, then the dispatching should be activated.
