### PR TITLE
Update CircleCi PHP image and Install PHP GD extension

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,9 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
-      - run: sudo docker-php-ext-install pdo_mysql exif
+      - run: sudo apt-get install -y libpng-dev libfreetype6-dev libjpeg-dev librabbitmq-dev
+      - run: sudo docker-php-ext-configure gd --with-gd --with-jpeg-dir --with-png-dir --with-freetype-dir
+      - run: sudo docker-php-ext-install pdo_mysql exif gd
       # load composer cache
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,9 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
-      - run: sudo apt-get install -y libpng-dev libfreetype6-dev libjpeg-dev librabbitmq-dev
-      - run: sudo docker-php-ext-configure gd --with-gd --with-jpeg-dir --with-png-dir --with-freetype-dir
+      - run: sudo apt-get update
+      - run: sudo apt-get -y --no-install-recommends install libfontconfig1 libxrender1 libxext6 zlib1g-dev libpng-dev libfreetype6-dev libjpeg62-turbo-dev
+      - run: sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* 
       - run: sudo docker-php-ext-install pdo_mysql exif gd
       # load composer cache
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,17 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/php:7.4-node-browsers
-      - image: circleci/node:4.8.2
+      - image: cimg/php:7.4-browsers
     working_directory: ~/project
     steps:
       - checkout
+      - run: |
+          php --version
+          node --version
       - run: sudo apt-get update
-      - run: sudo apt-get -y --no-install-recommends install libfontconfig1 libxrender1 libxext6 zlib1g-dev libpng-dev libfreetype6-dev libjpeg62-turbo-dev
-      - run: sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* 
-      - run: sudo docker-php-ext-install pdo_mysql exif gd
+      # dependency needed for gd exentions
+      - run: sudo apt-get -y --no-install-recommends install libfontconfig1 libxrender1 libxext6 zlib1g-dev libpng-dev libfreetype6-dev libjpeg8-dev
+      - run: sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
       # load composer cache
       - restore_cache:
           keys:


### PR DESCRIPTION
This PR contains the changes to update CircleCi PHP image to next-gen and also configure PHP GD extension. (The next-gen image already contains GD extension)