### PR TITLE
Create composite index for column tablename and record_id in history table

### DIFF
--- a/db/migrations/20220605084444_create_composte_index_on_history_table.php
+++ b/db/migrations/20220605084444_create_composte_index_on_history_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class CreateComposteIndexOnHistoryTable extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('history')
+            ->addIndex(['record_id', 'changedate'], [
+                'name' => 'recordid_changedate_composite_index',
+                'unique' => false,
+            ])
+            ->save()
+        ;
+        $this->table('history')
+            ->addIndex(['tablename', 'record_id', 'changedate'], [
+                'name' => 'tablename_recordid_changedate_composite_index',
+                'unique' => false,
+            ])
+            ->save()
+        ;
+    }
+}


### PR DESCRIPTION
This PR contains db clean up for history table; two composite index introduced based on the analysis of the Drop App queries.