### PR TITLE
Upgrade Sentry PHP Package to Version 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nyholm/psr7": "^1.4",
         "steampixel/simple-php-router": "^0.7.0",
         "guzzlehttp/guzzle": "^7.3",
-        "sentry/sentry": "^3.4",
+        "sentry/sentry": "^3.6",
         "php-http/curl-client": "^2.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3538,7 +3538,7 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "3.4.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",


### PR DESCRIPTION
This PR contain changes to upgrade sentry php package to the version 3.6