### PR TITLE
Reduce Box State Text Fade Animation Time - Part 2

### DIFF
--- a/assets/js/mobile.js
+++ b/assets/js/mobile.js
@@ -55,7 +55,7 @@ function getNewBoxState() {
             if (typeof result.message === 'object') {
                 $("#newstate").hide();
                 $("#newstate").html(result.message.box_state);
-                $("#newstate").fadeIn(2000);
+                $("#newstate").fadeIn(500);
                 
                 if(parseInt(result.message.box_state_id) === 2){
                     lostEl.checked = true;


### PR DESCRIPTION
The PR fixes one missing part of the mobile UI to reduce the fade animation.

Related PR: https://github.com/boxwise/dropapp/pull/519
