### PR TITLE
Add cron job for daily checking expired transfer agreements

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -28,6 +28,10 @@ cron:
   url: /cron/reseed-auth0.php
   target: staging
   schedule: every day 00:45
+- description: "check expired transfer agreements"
+  url: /cron/dailyroutine.php?action=check_expired_transfer_agreements
+  target: staging
+  schedule: every day 00:05
 
 # demo
 - description: "auth0 dailyroutine demo - check inactive users"
@@ -54,6 +58,10 @@ cron:
   url: /cron/reseed-auth0.php
   target: demo
   schedule: every 99999 hours
+- description: "check expired transfer agreements"
+  url: /cron/dailyroutine.php?action=check_expired_transfer_agreements
+  target: demo
+  schedule: every day 00:05
 
 # production
 - description: "auth0 dailyroutine production - check inactive users"
@@ -72,3 +80,7 @@ cron:
   url: /cron/dailyroutine.php?action=auth0_check_synk
   target: production
   schedule: every day 00:31
+- description: "check expired transfer agreements"
+  url: /cron/dailyroutine.php?action=check_expired_transfer_agreements
+  target: production
+  schedule: every day 00:05

--- a/cron/dailyroutine.php
+++ b/cron/dailyroutine.php
@@ -98,3 +98,11 @@ if ('auth0_check_synk' === $_GET['action']) {
         }
     }
 }
+
+if ('check_expired_transfer_agreements' === $_GET['action']) {
+    db_query('
+    UPDATE transfer_agreement
+    SET state = "Expired", terminated_on = UTC_TIMESTAMP()
+    WHERE valid_until < UTC_TIMESTAMP();
+');
+}


### PR DESCRIPTION
Not sure if DB updates work like that out of a cron job. I tested the command itself locally and it works.

Note that the `terminated_by` field will stay NULL.

The DB update might return something like the following, should/can we log that?

```
Query OK, 1 row affected (0.02 sec)
Rows matched: 1  Changed: 1  Warnings: 0
```
