### PR TITLE
Add Special Endpoint for V2 App Logout

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,6 +27,10 @@ Tracer::inSpan(
             loginWithRedirect();
         }
 
+        if ('logoutfromv2' == $action) {
+            logout("https://{$settings['auth0_domain']}/v2/logout?client_id={$settings['auth0_client_id']}&returnTo={$settings['v2_base_url']}");
+        }
+
         $cmsmain = new Zmarty();
 
         // Fill the organisation menu

--- a/library/lib/session.php
+++ b/library/lib/session.php
@@ -117,7 +117,7 @@ function logout($returnTo = null)
     session_unset();
     session_destroy();
     $auth0 = getAuth0($settings);
-    $url = $auth0->logout();
+    $auth0->logout();
 
     if ($returnTo) {
         redirect($returnTo);

--- a/library/lib/session.php
+++ b/library/lib/session.php
@@ -110,15 +110,18 @@ function isUserInSyncWithAuth0ByEmail($email)
     return isUserInSyncWithAuth0(db_value('SELECT id FROM cms_users WHERE email = :email OR (deleted IS NOT NULL AND email LIKE :deletedEmail)', ['email' => $email, 'deletedEmail' => $email.'.deleted%']));
 }
 
-function logout()
+function logout($returnTo = null)
 {
     global $settings;
 
     session_unset();
     session_destroy();
     $auth0 = getAuth0($settings);
-    $auth0->clear();
-    $auth0->logout();
+    $url = $auth0->logout();
+
+    if ($returnTo) {
+        redirect($returnTo);
+    }
 }
 
 function logoutWithRedirect()


### PR DESCRIPTION
This PR adds a special Endpoint for v2 logouts that solves the issue of v2 apps not logging out DropApp.