### PR TITLE
DB migration to add source/target quantity fields for shipment_detail table

### DIFF
--- a/db/migrations/20230620124521_add_quantity_to_shipment_detail.php
+++ b/db/migrations/20230620124521_add_quantity_to_shipment_detail.php
@@ -1,0 +1,24 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddQuantityToShipmentDetail extends AbstractMigration
+{
+    public function change()
+    {
+        $table = $this->table('shipment_detail');
+        $table
+            ->addColumn('source_quantity', 'integer', [
+                'null' => false,
+                'signed' => true,
+                'after' => 'target_product_id',
+            ])
+            ->addColumn('target_quantity', 'integer', [
+                'null' => true,
+                'signed' => true,
+                'after' => 'source_quantity',
+            ])
+            ->update()
+        ;
+    }
+}


### PR DESCRIPTION
- both fields are signed (like stock.items)
- target quantity is null when creating the shipment detail
