### PR TITLE
Update dispatching for demo/prod api services

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -33,10 +33,18 @@ dispatch:
 ## Demo
 - url: "v2-demo.boxtribute.org/*"
   service: v2-demo
-- url: "api-demo.boxtribute.org/*"
+# Fetch docs including images, CSS, and JS
+- url: "api-demo.boxtribute.org/docs/*"
+  service: api-demo
+# Intended for GraphQL explorer
+- url: "api-demo.boxtribute.org"
   service: api-demo
 ## Production
 - url: "v2.boxtribute.org/*"
   service: v2-production
-- url: "api.boxtribute.org/*"
+# Fetch docs including images, CSS, and JS
+- url: "api.boxtribute.org/docs/*"
+  service: api-production
+# Intended for GraphQL explorer
+- url: "api.boxtribute.org"
   service: api-production


### PR DESCRIPTION
Won't be deployed effectively since Google App Engine does not support `php80` runtime anymore ([CircleCI logs](https://app.circleci.com/pipelines/github/boxwise/dropapp/2691/workflows/26fd2615-3166-4754-b3d6-227e5704151b/jobs/5085)).

Deploying `dispatch.yaml` was entirely disabled since 5b6cb452 but re-enabled in e330d393.
