### PR TITLE
Fix: Remove Save and New Items Functionality in Edit Box

### DIFF
--- a/include/stock_edit.php
+++ b/include/stock_edit.php
@@ -228,7 +228,6 @@ if ($id) {
     addfield('line', '', '', ['aside' => true]);
 }
 addfield('created', 'Created', 'created', ['aside' => true]);
-addformbutton('submitandnew', 'Save and new item');
 
 // place the form elements and data in the template
 $cmsmain->assign('data', $data);


### PR DESCRIPTION
This PR includes a small update to remove the "Save and New Item" button from the edit box page.