### PR TITLE
Fix: Show Save and New Item Button on New Box

### DIFF
--- a/include/stock_edit.php
+++ b/include/stock_edit.php
@@ -229,6 +229,10 @@ if ($id) {
 }
 addfield('created', 'Created', 'created', ['aside' => true]);
 
+if (!$id) {
+    addformbutton('submitandnew', 'Save and new item');
+}
+
 // place the form elements and data in the template
 $cmsmain->assign('data', $data);
 $cmsmain->assign('formelements', $formdata);


### PR DESCRIPTION
This minor fix ensures the `Save and New Item` button is displayed only on the new box creation form.