### PR TITLE
Handle boxtribute_god role in isUserInSyncWithAuth0 check

### DIFF
--- a/library/lib/auth0.php
+++ b/library/lib/auth0.php
@@ -270,6 +270,9 @@ function isUserInSyncWithAuth0($userId)
         }
 
         foreach ($auth0UserRoles as $auth0UserRole) {
+            if ('boxtribute_god' == $auth0UserRole['name']) {
+                continue;
+            }
             $auth0Roles[] = $auth0UserRole['id'];
             $tmp = explode('_', (string) $auth0UserRole['name'], 3);
             if ((bool) $tmp[1]) {


### PR DESCRIPTION
This will fix errors of the `dailyroutine.php?action=auth0_active_users` cron job like 

```
PHP error: Roles of user with id 6 is out of sync between DB and Auth0.
Base ID god, is associated in Auth0 by the Roles, but not in DB
```

The issue was that the script assumed all roles to be of form `base_X_coordinator` and tried to compare the parsed base IDs and the one's that the user has assigned via their usergroup in `cms_usergroups_camps`. For the `boxtribute_god` role, the naming is different; and for the corresponding usergroup, no camps are assigned.

Until the next dropapp deploy, these changes won't have any effect.
