### PR TITLE
Fix Auth0 Production Cron Job Check of Inactive Users 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ phpmyadmin/*
 node_modules
 cypress.env.json
 db/queries/*.csv
+.php-cs-fixer.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "[php]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "fterrag.vscode-php-cs-fixer"
+        "editor.defaultFormatter": "junstyle.php-cs-fixer"
     },
     "php-cs-fixer.rules": "@PhpCsFixer",
     "intelephense.format.enable": false

--- a/library/lib/auth0.php
+++ b/library/lib/auth0.php
@@ -228,14 +228,13 @@ function isUserInSyncWithAuth0($userId)
     } elseif ($dbUser && $auth0User && $hasActiveBase) {
         $validationResult = [];
 
+        $validationResult['id'] = ($auth0User['identities'][0]['user_id'] == $userId) ? 'true' : 'false';
         // deleted user no longer has name/email/usergroup/organisation/base
         // ref. trello card: https://trello.com/c/68xRRHny
         if ('0000-00-00 00:00:00' != $dbUser['deleted'] && !is_null($dbUser['deleted'])) {
-            $validationResult['id'] = ($auth0User['identities'][0]['user_id'] == $userId) ? 'true' : 'false';
             $validationResult['last_blocked_date'] = (!empty($auth0User['app_metadata']['last_blocked_date']) && $auth0User['app_metadata']['last_blocked_date'] == $dbUser['deleted']) ? 'true' : 'false';
             $validationResult['deleted'] = (!empty($auth0User['blocked']) && $auth0User['blocked']) ? 'true' : 'false';
         } else {
-            $validationResult['id'] = ($auth0User['identities'][0]['user_id'] == $userId) ? 'true' : 'false';
             $validationResult['email'] = ($auth0User['email'] == (preg_match('/\.deleted\.\d+/', (string) $dbUser['email']) ? preg_replace('/\.deleted\.\d+/', '', (string) $dbUser['email']) : $dbUser['email'])) ? 'true' : 'false';
             $validationResult['name'] = ($auth0User['name'] == $dbUser['naam']) ? 'true' : 'false';
             $validationResult['usergroup_id'] = ($auth0User['app_metadata']['usergroup_id'] == $dbUser['cms_usergroups_id'] || null == $dbUser['cms_usergroups_id']) ? 'true' : 'false';

--- a/library/lib/auth0.php
+++ b/library/lib/auth0.php
@@ -241,8 +241,8 @@ function isUserInSyncWithAuth0($userId)
             $validationResult['organisation_id'] = ($auth0User['app_metadata']['organisation_id'] == $dbUser['organisation_id'] || null == $dbUser['cms_organisation_id']) ? 'true' : 'false';
         }
 
-        $auth0ActiveBaseIds = isset($auth0User['active_base_ids']) && is_array($auth0User['active_base_ids']) ? $auth0User['active_base_ids'] : [];
-        $dbUserActiveBaseIds = isset($dbUser['active_base_ids']) && is_array($dbUser['active_base_ids']) ? $dbUser['active_base_ids'] : [];
+        $auth0ActiveBaseIds = isset($auth0User['active_base_ids']) && is_array($auth0User['active_base_ids']) ? array_values($auth0User['active_base_ids']) : [];
+        $dbUserActiveBaseIds = isset($dbUser['active_base_ids']) && is_array($dbUser['active_base_ids']) ? array_values($dbUser['active_base_ids']) : [];
 
         // Sort the base ids to ensure they can be compared regardless of order
         sort($auth0ActiveBaseIds);


### PR DESCRIPTION
The PR switches the PHP formatter to `junstyle.php-cs-fixer` due to the discontinuation of the previous one, and updates the query to check only active bases and fix the cron job for inactive users.