### PR TITLE
Avoid history table entries for transactions

### DIFF
--- a/include/check_out.php
+++ b/include/check_out.php
@@ -115,7 +115,7 @@ if (!$ajax) {
             $notificationText = $notificationText.'<li>'.$item['count'].'x '.$item['nameWithoutPrice'].' - '.$_POST['drops'] * (-1).' '.$camp['currencyname'].'</li>';
 
             $handler = new formHandler($table);
-            $id = $handler->savePost($savekeys);
+            $id = $handler->savePost($savekeys, [], false);
         }
         $notificationText = $notificationText.'</ul> </br> <b>Thanks for helping!</b>';
         $return = ['success' => true, 'message' => $notificationText, 'redirect' => '?action=check_out'];

--- a/include/check_out.php
+++ b/include/check_out.php
@@ -66,7 +66,7 @@ if (!$ajax) {
         foreach ($ids as $id) {
             verify_campaccess_people(db_value('SELECT people_id FROM transactions WHERE id=:id', ['id' => $id]));
         }
-        [$success, $message, $redirect] = listDelete($table, $ids);
+        [$success, $message, $redirect] = listDelete($table, $ids, false, null, false);
         $return = ['success' => $success, 'message' => $message, 'redirect' => false, 'action' => "$('#field_people_id').trigger('change')"];
 
         echo json_encode($return);

--- a/include/people_edit.php
+++ b/include/people_edit.php
@@ -11,7 +11,7 @@ if ($_POST) {
         foreach ($ids as $id) {
             verify_campaccess_people(db_value('SELECT people_id FROM transactions WHERE id=:id', ['id' => $id]));
         }
-        [$success, $message, $redirect] = listDelete('transactions', $ids);
+        [$success, $message, $redirect] = listDelete('transactions', $ids, false, null, false);
 
         $return = ['success' => $success, 'message' => $message, 'redirect' => $redirect, 'action' => $aftermove];
 

--- a/library/lib/formhandler.php
+++ b/library/lib/formhandler.php
@@ -14,14 +14,14 @@ class formHandler
         $this->id = intval($_POST['id']);
     }
 
-    public function savePost($keys, $nullIfEmptyKeys = [])
+    public function savePost($keys, $nullIfEmptyKeys = [], $saveHistory = true)
     {
         $this->nullIfEmpty = array_fill_keys($nullIfEmptyKeys, null);
         $this->keys = $keys;
         $this->saveCreatedModified();
 
         $this->modifyData($this->keys);
-        $this->buildQuery();
+        $this->buildQuery($saveHistory);
 
         return $this->id;
     }
@@ -124,7 +124,7 @@ class formHandler
         }
     }
 
-    public function buildQuery(): void
+    public function buildQuery($saveHistory): void
     {
         $updatequery = 'UPDATE '.$this->table.' SET ';
         $insertquery = 'INSERT INTO '.$this->table;
@@ -150,7 +150,9 @@ class formHandler
         $insertquery .= ' ('.join(', ', $insertqueryfields).') VALUES ('.join(', ', $insertqueryfields2).')';
 
         if ($this->id > 0) {
-            $this->saveChangeHistory();
+            if ($saveHistory) {
+                $this->saveChangeHistory();
+            }
             if ($this->debug) {
                 dump($updatequery);
                 dump(join(',', $queryvalues));
@@ -164,7 +166,9 @@ class formHandler
             } else {
                 db_query($insertquery, $queryvalues);
                 $this->id = db_insertid();
-                $this->saveNewrecordInHistory();
+                if ($saveHistory) {
+                    $this->saveNewrecordInHistory();
+                }
             }
         }
     }

--- a/library/lib/list.php
+++ b/library/lib/list.php
@@ -139,7 +139,7 @@ function listBulkRealDelete($table, $ids, $uri = false)
     return [false, $translate['cms_list_deleteerror'], false];
 }
 
-function listDelete($table, $ids, $uri = false, $fktables = null)
+function listDelete($table, $ids, $uri = false, $fktables = null, $saveHistory = true)
 {
     global $translate, $action;
 
@@ -185,7 +185,7 @@ function listDelete($table, $ids, $uri = false, $fktables = null)
             } else {
                 $result = db_query('DELETE FROM '.$table.' WHERE id = :id'.($hasPrevent ? ' AND NOT preventdelete' : ''), ['id' => $id]);
                 $count += $result->rowCount();
-                if ($result->rowCount()) {
+                if ($result->rowCount() && $saveHistory) {
                     simpleSaveChangeHistory($table, $id, 'Record deleted');
                 }
             }


### PR DESCRIPTION
Please check trello card for background info.

- Make saving history optional when list-deleting transactions
- Make saving history optional when creating transactions
