### PR TITLE
Fix Old Domain Forwarding

### DIFF
--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -54,7 +54,7 @@ if (('market.drapenihavet.no' == $_SERVER['HTTP_HOST']) || ('www.market.drapenih
 // Fix domain forwarding for old boxwise.co subdomains
 // trello ref. https://trello.com/c/t6sW9Qg7
 
-$validSubdomains = ['staging', 'www.staging'];
+$validSubdomains = ['staging', 'www.staging', 'app', 'demo'];
 $validRoutes = [
     '#^/(\?.*)?$#', // Root path and any query string
     '#^/index\.php(\?.*)?$#',
@@ -66,7 +66,7 @@ $validRoutes = [
 
 if (false !== strpos($_SERVER['HTTP_HOST'], 'boxwise.co')) {
     $fullUrl = $_SERVER['REQUEST_SCHEME'].'://'.$fullHost.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
-    $parsedUrl = @parse_url('http://'.$fullUrl);
+    $parsedUrl = @parse_url($fullUrl);
     $host = $parsedUrl['host'] ?? '';
     $path = $parsedUrl['path'] ?? '/';
     $query = !empty($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
@@ -99,6 +99,8 @@ if (false !== strpos($_SERVER['HTTP_HOST'], 'boxwise.co')) {
         return;
     }
 }
+
+exit;
 
 $parsedUrl = @parse_url($_SERVER['REQUEST_URI'])['path'];
 Tracer::inSpan(

--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -92,12 +92,12 @@ if (false !== strpos($_SERVER['HTTP_HOST'], 'boxwise.co')) {
                 return;
             }
         }
-
-        // Redirect to default URL if no valid route matches
-        header('Location: https://www.boxtribute.org', true, 301);
-
-        return;
     }
+
+    // Redirect to default URL if no valid route matches
+    header('Location: https://www.boxtribute.org', true, 301);
+
+    return;
 }
 
 $parsedUrl = @parse_url($_SERVER['REQUEST_URI'])['path'];

--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -100,8 +100,6 @@ if (false !== strpos($_SERVER['HTTP_HOST'], 'boxwise.co')) {
     }
 }
 
-exit;
-
 $parsedUrl = @parse_url($_SERVER['REQUEST_URI'])['path'];
 Tracer::inSpan(
     ['name' => ('gcloud-entry:'.$parsedUrl)],

--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -53,6 +53,17 @@ if (('market.drapenihavet.no' == $_SERVER['HTTP_HOST']) || ('www.market.drapenih
 
 // Fix domain forwarding for old boxwise.co subdomains
 // trello ref. https://trello.com/c/t6sW9Qg7
+
+$validSubdomains = ['staging', 'www.staging'];
+$validRoutes = [
+    '#^/(\?.*)?$#', // Root path and any query string
+    '#^/index\.php(\?.*)?$#',
+    '#^/flip/scan\.php(\?.*)?$#',
+    '#^/ajax\.php(\?.*)?$#',
+    '#^/mobile\.php(\?.*)?$#',
+    '#^/pdf/(workshopcard|bicyclecard|idcard|qr|dryfood)\.php(\?.*)?$#',
+];
+
 if (false !== strpos($_SERVER['HTTP_HOST'], 'boxwise.co')) {
     $fullUrl = $_SERVER['REQUEST_SCHEME'].'://'.$fullHost.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
     $parsedUrl = @parse_url('http://'.$fullUrl);

--- a/gcloud-entry.php
+++ b/gcloud-entry.php
@@ -65,7 +65,7 @@ $validRoutes = [
 ];
 
 if (false !== strpos($_SERVER['HTTP_HOST'], 'boxwise.co')) {
-    $fullUrl = $_SERVER['REQUEST_SCHEME'].'://'.$fullHost.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
+    $fullUrl = $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'];
     $parsedUrl = @parse_url($fullUrl);
     $host = $parsedUrl['host'] ?? '';
     $path = $parsedUrl['path'] ?? '/';


### PR DESCRIPTION
This PR corrects domain forwarding for `boxwise.co` subdomains, ensuring proper redirection to `boxtribute.org` subdomains or a default URL based on the path and subdomain.

NOTE: Once this PR is merged, we need to update the **CNAME** records for `boxwise.co` subdomains.