### PR TITLE
Null-size migration for measure products

### DIFF
--- a/db/migrations/20240930122935_make_stock_size_nullable.php
+++ b/db/migrations/20240930122935_make_stock_size_nullable.php
@@ -7,7 +7,7 @@ class MakeStockSizeNullable extends AbstractMigration
     public function up(): void
     {
         $stock = $this->table('stock');
-        $stock->changeColumn('size_id', 'integer', ['null' => true])
+        $stock->changeColumn('size_id', 'integer', ['null' => true, 'signed' => false])
             ->update()
         ;
     }
@@ -15,7 +15,13 @@ class MakeStockSizeNullable extends AbstractMigration
     public function down(): void
     {
         $stock = $this->table('stock');
-        $stock->changeColumn('size_id', 'integer', ['null' => false])
+        $stock->dropForeignKey('size_id')
+            ->update()
+        ;
+        $stock->changeColumn('size_id', 'integer', ['null' => false, 'signed' => false])
+            ->addForeignKey('size_id', 'sizes', 'id', [
+                'delete' => 'RESTRICT', 'update' => 'CASCADE',
+            ])
             ->update()
         ;
     }

--- a/db/migrations/20240930122935_make_stock_size_nullable.php
+++ b/db/migrations/20240930122935_make_stock_size_nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MakeStockSizeNullable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $stock = $this->table('stock');
+        $stock->changeColumn('size_id', 'integer', ['null' => true])
+            ->update()
+        ;
+    }
+
+    public function down(): void
+    {
+        $stock = $this->table('stock');
+        $stock->changeColumn('size_id', 'integer', ['null' => false])
+            ->update()
+        ;
+    }
+}

--- a/db/migrations/20240930123110_make_shipment_detail_source_size_nullable.php
+++ b/db/migrations/20240930123110_make_shipment_detail_source_size_nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class MakeShipmentDetailSourceSizeNullable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $shipment_detail = $this->table('shipment_detail');
+        $shipment_detail->changeColumn('source_size_id', 'integer', ['null' => true])
+            ->update()
+        ;
+    }
+
+    public function down(): void
+    {
+        $shipment_detail = $this->table('shipment_detail');
+        $shipment_detail->changeColumn('source_size_id', 'integer', ['null' => false])
+            ->update()
+        ;
+    }
+}

--- a/db/migrations/20240930123110_make_shipment_detail_source_size_nullable.php
+++ b/db/migrations/20240930123110_make_shipment_detail_source_size_nullable.php
@@ -7,7 +7,7 @@ class MakeShipmentDetailSourceSizeNullable extends AbstractMigration
     public function up(): void
     {
         $shipment_detail = $this->table('shipment_detail');
-        $shipment_detail->changeColumn('source_size_id', 'integer', ['null' => true])
+        $shipment_detail->changeColumn('source_size_id', 'integer', ['null' => true, 'signed' => false])
             ->update()
         ;
     }
@@ -15,7 +15,13 @@ class MakeShipmentDetailSourceSizeNullable extends AbstractMigration
     public function down(): void
     {
         $shipment_detail = $this->table('shipment_detail');
-        $shipment_detail->changeColumn('source_size_id', 'integer', ['null' => false])
+        $shipment_detail->dropForeignKey('source_size_id')
+            ->update()
+        ;
+        $shipment_detail->changeColumn('source_size_id', 'integer', ['null' => false, 'signed' => false])
+            ->addForeignKey('source_size_id', 'sizes', 'id', [
+                'delete' => 'RESTRICT', 'update' => 'CASCADE',
+            ])
             ->update()
         ;
     }


### PR DESCRIPTION
- Add migrations for new sizegroups, units, and stock unit/value
- Add DB migrations to make size fields nullable
