### PR TITLE
DB migration for shareable-link table

### DIFF
--- a/db/migrations/20250127114447_add_shareable_link_table.php
+++ b/db/migrations/20250127114447_add_shareable_link_table.php
@@ -33,24 +33,29 @@ class AddShareableLinkTable extends AbstractMigration
             ])
             ->addColumn('base_id', 'integer', [
                 'null' => true,
+                'signed' => false,
                 'after' => 'view',
             ])
             ->addColumn('url_parameters', 'string', [
                 'null' => true,
-                'limit' => 65535,
+                'limit' => 2000,
                 'after' => 'base_id',
             ])
             ->addColumn('created_on', 'datetime', [
                 'null' => false,
                 'after' => 'url_parameters',
             ])
-            ->addColumn('created_by', 'integer', [
+            ->addColumn('created_by_id', 'integer', [
                 'null' => true,
                 'signed' => false,
                 'after' => 'created_on',
             ])
 
-            ->addForeignKey('created_by', 'cms_users', 'id', [
+            ->addForeignKey('created_by_id', 'cms_users', 'id', [
+                'delete' => 'SET_NULL', 'update' => 'CASCADE',
+            ])
+
+            ->addForeignKey('base_id', 'camps', 'id', [
                 'delete' => 'SET_NULL', 'update' => 'CASCADE',
             ])
 
@@ -58,7 +63,7 @@ class AddShareableLinkTable extends AbstractMigration
                 'unique' => true,
                 'name' => 'shareable_link_code',
             ])
-            ->addIndex(['created_by'], ['name' => 'shareable_link_created_by'])
+
             ->create()
         ;
     }

--- a/db/migrations/20250127114447_add_shareable_link_table.php
+++ b/db/migrations/20250127114447_add_shareable_link_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class AddShareableLinkTable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('shareable_link', [
+            'id' => true,
+            'primary_key' => ['id'],
+            'engine' => 'InnoDB',
+            'signed' => false,
+            'encoding' => 'utf8',
+            'collation' => 'utf8_general_ci',
+            'comment' => '',
+            'row_format' => 'DYNAMIC',
+        ]);
+
+        $table->addColumn('code', 'string', [
+            'null' => false,
+            'limit' => 255,
+            'after' => 'id',
+        ])
+            ->addColumn('valid_until', 'datetime', [
+                'null' => true,
+                'after' => 'code',
+            ])
+            ->addColumn('view', 'string', [
+                'null' => false,
+                'limit' => 255,
+                'after' => 'valid_until',
+            ])
+            ->addColumn('base_id', 'integer', [
+                'null' => true,
+                'after' => 'view',
+            ])
+            ->addColumn('url_parameters', 'string', [
+                'null' => true,
+                'limit' => 65535,
+                'after' => 'base_id',
+            ])
+            ->addColumn('created_on', 'datetime', [
+                'null' => false,
+                'after' => 'url_parameters',
+            ])
+            ->addColumn('created_by', 'integer', [
+                'null' => true,
+                'signed' => false,
+                'after' => 'created_on',
+            ])
+
+            ->addForeignKey('created_by', 'cms_users', 'id', [
+                'delete' => 'SET_NULL', 'update' => 'CASCADE',
+            ])
+
+            ->addIndex(['code'], [
+                'unique' => true,
+                'name' => 'shareable_link_code',
+            ])
+            ->addIndex(['created_by'], ['name' => 'shareable_link_created_by'])
+            ->create()
+        ;
+    }
+
+    public function down(): void
+    {
+        $this->table('shareable_link')->drop()->save();
+    }
+}

--- a/library/constants.php
+++ b/library/constants.php
@@ -412,6 +412,7 @@ $rolesToActions = [
         'view_transfer_agreements',
         'view_shipments',
         'fill_shipment',
+        'create_shareable_link',
     ],
 
     'coordinator' => [
@@ -443,6 +444,7 @@ $rolesToActions = [
         'view_transfer_agreements',
         'view_shipments',
         'fill_shipment',
+        'create_shareable_link',
     ],
 
     'warehouse_volunteer' => [


### PR DESCRIPTION
open questions:
1. `code` column as fixed-length char type?
2. `url_parameters` column max-length (65535) sufficient?
3. extra datetime column `last_accessed_on` and integer column `number_of_accesses` to keep track of access, and have some means for basic rate-/access-limiting (then again, these would require DB-write access for the public endpoint, not sure if we want that)?

Answers:
1. not important for now
2. use max-length 2000
3. for rate-limiting we'd use Google Armor instead of doing a software/DB solution. For tracking number of accesses internally we can use heap, for externally tracking it we might want to have an extra table at some point.
