### PR TITLE
Dropapp: Rename Stock Overview Page title to Stock Planning

### DIFF
--- a/include/stock_overview.php
+++ b/include/stock_overview.php
@@ -7,7 +7,7 @@ $ajax = checkajax();
 if (!$ajax) {
     initlist();
 
-    $cmsmain->assign('title', 'Stock Overview');
+    $cmsmain->assign('title', 'Stock Planning');
 
     listsetting('allowcopy', false);
     listsetting('allowadd', false);


### PR DESCRIPTION
This PR renames the title of “Stock overview” to “Stock planning.”