### PR TITLE
Add Tab In Manage Product And Restrict Editing For Standard ASSORT Products

### DIFF
--- a/include/products.php
+++ b/include/products.php
@@ -37,7 +37,7 @@ if (!$ajax) {
         $count += $d['items'];
     }
 
-    addcolumn('text', 'Product name', 'name');
+    addcolumn('text_cond_icon', 'Product name', 'name');
     addcolumn('text', 'Gender', 'gender');
     addcolumn('text', 'Sizegroup', 'sizegroup');
     if ($count) {

--- a/include/products.php
+++ b/include/products.php
@@ -19,7 +19,8 @@ if (!$ajax) {
                 g.label AS gender, 
                 CONCAT(products.value," '.$_SESSION['camp']['currencyname'].'") AS drops, 
                 COALESCE(SUM(s.items),0) AS items, 
-                IF(SUM(s.items),1,0) AS preventdelete 
+                IF(SUM(s.items) OR products.standard_product_id IS NOT NULL, 1, 0) AS preventdelete,
+                IF(products.standard_product_id,1,0) AS preventedit
             FROM products
 			LEFT OUTER JOIN genders AS g ON g.id = products.gender_id
 			LEFT OUTER JOIN sizegroup AS sg ON sg.id = products.sizegroup_id

--- a/include/products.php
+++ b/include/products.php
@@ -4,7 +4,9 @@ $table = $action;
 $ajax = checkajax();
 if (!$ajax) {
     initlist();
-
+    listsetting('haspagemenu', true);
+    addpagemenu('base_products', strtoupper((string) $_SESSION['camp']['name']).' PRODUCTS', ['active' => true, 'link' => '?action=products', 'testid' => 'products']);
+    addpagemenu('assort_products', 'ASSORT STANDARD PRODUCTS', ['link' => $settings['v2_base_url'].'/bases/'.$_SESSION['camp']['id'].'/products']);
     $cmsmain->assign('title', 'Products');
     listsetting('search', ['name', 'g.label', 'products.comments']);
 

--- a/include/products_edit.php
+++ b/include/products_edit.php
@@ -5,10 +5,13 @@ $action = 'products_edit';
 
 if ($_POST) {
     $handler = new formHandler($table);
-
+    // Trelo ref https://trello.com/c/NRHVvf2u
+    $product = db_row('SELECT standard_product_id FROM products WHERE id = :id', ['id' => $_POST['id']]);
+    if (!empty($product['standard_product_id'])) {
+        throw new Exception('This product is a STANDARD ASSORT PRODUCT and cannot be edited');
+    }
     $savekeys = ['name', 'gender_id', 'value', 'category_id', 'maxperadult', 'maxperchild', 'sizegroup_id', 'camp_id', 'comments', 'stockincontainer'];
     $id = $handler->savePost($savekeys);
-
     redirect('?action='.$_POST['_origin']);
 }
 

--- a/templates/cms_list_text_cond_icon.tpl
+++ b/templates/cms_list_text_cond_icon.tpl
@@ -1,0 +1,10 @@
+{if $listdata[$column['field']]['breakall']}<span class="breakall">{/if}
+{$row[$column['field']]|strip_tags:false|truncate}
+{if !empty($row['standard_product_id'])}
+    <span class="list-toggle-value hide">{$row['standard_product_id']}</span>
+    <span class="list-toggle inside-list-start-operation stay active">
+        <span class="fa fa-circle-o"></span>
+        <span class="fa fa-check-circle active" title="This product is part of the ASSORT standard"></span>
+    </span>
+{/if}
+{if $listdata[$column['field']]['breakall']}</span>{/if}


### PR DESCRIPTION
- **change the stock overview tile to stock planning**
- **add a tab bar on top of the manage products**
- **add checkmark after the name in the table for the assort products with tooltip**
- **prevent assort delete and edit of the assort product**
- **prevent edit of standard assort product**
