### PR TITLE
Hide None-gender label in most-popular-item name on start page

### DIFF
--- a/include/start.php
+++ b/include/start.php
@@ -29,7 +29,7 @@ if (isset($_SESSION['camp']['id'])) {
     $data['marketdays'] = db_value('SELECT COUNT(DISTINCT(DATE_FORMAT(transaction_date,"%d-%m-%Y"))) FROM transactions AS t, people AS p WHERE t.people_id = p.id AND p.camp_id = :camp_id', ['camp_id' => $_SESSION['camp']['id']]);
     $data['bank'] = db_value('SELECT SUM(drops) FROM people AS p, transactions AS t WHERE p.camp_id = :camp_id AND t.people_id = p.id ', ['camp_id' => $_SESSION['camp']['id']]);
 
-    $popular = db_row('SELECT SUM(count) AS count, CONCAT(p.name," ", g.label) AS product FROM transactions AS t, products AS p, genders AS g WHERE g.id = p.gender_id AND p.id = t.product_id AND p.camp_id = :camp_id GROUP BY product_id ORDER BY SUM(count) DESC LIMIT 1', ['camp_id' => $_SESSION['camp']['id']]);
+    $popular = db_row('SELECT SUM(count) AS count, IF(g.id = 10, p.name, CONCAT(p.name," ", g.label)) AS product FROM transactions AS t, products AS p, genders AS g WHERE g.id = p.gender_id AND p.id = t.product_id AND p.camp_id = :camp_id GROUP BY product_id ORDER BY SUM(count) DESC LIMIT 1', ['camp_id' => $_SESSION['camp']['id']]);
     $data['popularcount'] = intval($popular['count']);
     $data['popularname'] = $popular['product'] ?: 'none';
 

--- a/templates/start-market.tpl
+++ b/templates/start-market.tpl
@@ -141,19 +141,35 @@ var chart = AmCharts.makeChart( "chartdiv2", {
 	<h1>Hello there!</h1>
 	
 	{if $smarty.session.camp['market']}
-		<h1 class="light">
-			There {if $data['residents']==1} is {else} are {/if} currently <span class="number">{$data['residents']}</span> {if $data['residents']==1} person {else} people {/if} living in <span class="number">{$data['families']}</span> {if $data['families']==1} familiy {else} families {/if} in {$currentcamp['name']}.
-      <span class="men">{($data['totalmen'])}</span> {if $data['totalmen']==1} is {else} are {/if} male (<span class="men">{$data['menperc']|round}%</span>) and <span class="women">{$data['totalwomen']}</span> {if $data['totalwomen']==1} is {else} are {/if} female (<span class="women">{$data['womenperc']|round}%</span>).
-      <span class="number">{$data['children']}</span> {if $data['children']==1}person is {else} people are {/if} {$smarty.session.camp['adult_age']-1} or younger (<span class="number">{($data['childrenprcnt'])|round}%</span>).
-      <br>
+    <h1 class="light">
+        There {if $data['residents']==1} is {else} are {/if} currently 
+        <span class="number">{$data['residents']}</span> 
+        {if $data['residents']==1} person {else} people {/if} living in 
+        <span class="number">{$data['families']}</span> 
+        {if $data['families']==1} family {else} families {/if} in {$currentcamp['name']}.
+        
+        <span class="men">{$data['totalmen']}</span> 
+        {if $data['totalmen']==1} is {else} are {/if} male 
+        (<span class="men">{$data['menperc']|round}%</span>) and 
+        
+        <span class="women">{$data['totalwomen']}</span> 
+        {if $data['totalwomen']==1} is {else} are {/if} female 
+        (<span class="women">{$data['womenperc']|round}%</span>).
+
+        {assign var="child_age" value=$smarty.session.camp['adult_age']-1}
+        {if $child_age < 0}
+            {assign var="child_age" value=0}
+        {/if}
+
+        {if $data['children'] > 0}
+            <span class="number">{$data['children']}</span> 
+            {if $data['children']==1} person is {else} people are {/if} 
+            {$child_age} or younger 
+            (<span class="number">{$data['childrenprcnt']|round}%</span>).
+        {/if}
+        
+        <br>
     </h1>
-    <h1 class = "light">
-    <hr />
-      {$data['weeklabel']} week, {if $data['newpeople']}<span class="number">{$data['newpeople']}</span>{else}no{/if} new {if $data['newpeople']==1} beneficiary was {else} beneficiaries were {/if} registered in {$currentcamp['name']}.
- 			{if isset($data['notregistered'])}
-  				Additionally there {if $data['notregistered']==1}is {else} are {/if} <span class="number">{$data['notregistered']}</span> unregistered {if $data['notregistered']==1} person{else} people{/if}.
-  			{/if}
-		</h1>
 	{/if}
 <hr />
 

--- a/templates/start-market.tpl
+++ b/templates/start-market.tpl
@@ -173,10 +173,19 @@ var chart = AmCharts.makeChart( "chartdiv2", {
 	{/if}
 <hr />
 
-<h1 class="light">
 {if $smarty.session.camp['market']}
-  All beneficiaries together own <span class="number">{$data['bank']|number_format:0:",":"."}</span> {$currentcamp['currencyname']}.
-	<span class="number">{$data['sold']|number_format:0:",":"."}</span> items have been sold in the shop in <span class="number">{$data['marketdays']}</span> opening days. The most popular item is <span class="number">{$data['popularname']}</span>, with <span class="number">{$data['popularcount']|number_format:0:",":"."}</span> items sold.</h1>
+  <h1 class="light">
+    All beneficiaries together own 
+    <span class="number">{if !empty($data['bank'])}{$data['bank']|number_format:0:",":"."}{else}0{/if}</span> {$currentcamp['currencyname']}.
+    
+    <span class="number">{if !empty($data['sold'])}{$data['sold']|number_format:0:",":"."}{else}0{/if}</span> items have been sold in the shop in 
+    <span class="number">{if !empty($data['marketdays'])}{$data['marketdays']}{else}0{/if}</span> opening days. 
+    
+    {if !empty($data['popularname']) && $data['popularname'] != 'none'}
+      The most popular item is <span class="number">{$data['popularname']}</span>, with 
+      <span class="number">{if !empty($data['popularcount'])}{$data['popularcount']|number_format:0:",":"."}{else}0{/if}</span> items sold.
+    {/if}
+  </h1>
 {/if}
 
 {if $smarty.session.camp['bicycle']}<hr />


### PR DESCRIPTION
Maybe more efficient to do

```
select
	SUM(count) as count,
	g.id as gender_id,
	p.name as product_name
FROM transactions t
        ...
```
instead, and then the name combination logic, deepening on `gender_id`, when assigning `$data['popularname']`.
