### PR TITLE
Hide StandardProducts tab for users with beta-level less than  4

### DIFF
--- a/include/products.php
+++ b/include/products.php
@@ -5,7 +5,12 @@ $ajax = checkajax();
 if (!$ajax) {
     initlist();
     listsetting('haspagemenu', true);
-    addpagemenu('base_products', strtoupper((string) $_SESSION['camp']['name']).' PRODUCTS', ['active' => true, 'link' => '?action=products', 'testid' => 'products']);
+    // trello ref. https://trello.com/c/sTm0aEG1
+    // Hide StandardProducts tab for users with beta-level < 4
+    $betaUser = isset($_SESSION['auth0_user']['https://www.boxtribute.com/beta_user']) ? ((int) $_SESSION['auth0_user']['https://www.boxtribute.com/beta_user']) : 0;
+    if ($betaUser >= 4) {
+        addpagemenu('base_products', strtoupper((string) $_SESSION['camp']['name']).' PRODUCTS', ['active' => true, 'link' => '?action=products', 'testid' => 'products']);
+    }
     addpagemenu('assort_products', 'ASSORT STANDARD PRODUCTS', ['link' => $settings['v2_base_url'].'/bases/'.$_SESSION['camp']['id'].'/products']);
     $cmsmain->assign('title', 'Products');
     listsetting('search', ['name', 'g.label', 'products.comments']);


### PR DESCRIPTION
This PR hides standard product tabs when a beta user has fewer than 4.