### PR TITLE
Addition of Flexible Beneficiary Fields

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -654,8 +654,26 @@ function conditionalToggle(checkboxName, textFieldName) {
         document.addEventListener("change", function (e) {
             if (e.target === checkbox) {
                 targetField.disabled = !checkbox.checked;
-                if (checkbox.checked) targetField.focus();
-                else targetField.value = "";
+                if (checkbox.checked) {
+                    targetField.focus(); 
+                    targetField.setAttribute("aria-required", "true");
+                    targetField.setAttribute("required", "required");
+                } else {
+                    targetField.value = "";
+                    targetField.removeAttribute("aria-required");
+                    targetField.removeAttribute("required");
+                    targetField.classList.remove("error");
+                    if (targetField.hasAttribute("data-hasqtip")) {
+                        const qtipId = targetField.getAttribute("data-hasqtip");
+                        const tooltipElement = document.getElementById(`qtip-${qtipId}`);
+                        if (tooltipElement) {
+                            tooltipElement.remove();
+                        }
+                        targetField.removeAttribute("data-hasqtip");
+                        targetField.removeAttribute("aria-describedby");
+                        targetField.setAttribute("aria-invalid", "false");
+                    }
+                }
             }
         });
     }

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -644,3 +644,19 @@ function toggleFood() {
 function toggleBikes() {
     $("#tabid_bicycle").toggleClass("hidden");
 }
+
+// Function to handle conditional toggling based on checkbox field
+function conditionalToggle(checkboxName, textFieldName) {
+    const checkbox = document.querySelector(`input[name="${checkboxName}"]`);
+    const targetField = document.querySelector(`input[name="${textFieldName}"]`);
+
+    if (checkbox && targetField) {
+        document.addEventListener("change", function (e) {
+            if (e.target === checkbox) {
+                targetField.disabled = !checkbox.checked;
+                if (checkbox.checked) targetField.focus();
+                else targetField.value = "";
+            }
+        });
+    }
+}

--- a/db/migrations/20250328140848_add_additional_fields_to_people.php
+++ b/db/migrations/20250328140848_add_additional_fields_to_people.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddAdditionalFieldsToPeople extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('people')
+            ->addColumn('customfield1_value', 'string', ['default' => '', 'null' => false])
+            ->addColumn('customfield2_value', 'string', ['default' => '', 'null' => false])
+            ->addColumn('customfield3_value', 'string', ['default' => '', 'null' => false])
+            ->addColumn('customfield4_value', 'datetime', ['default' => null, 'null' => true])
+            ->save()
+        ;
+    }
+}

--- a/db/migrations/20250328140848_add_additional_fields_to_people.php
+++ b/db/migrations/20250328140848_add_additional_fields_to_people.php
@@ -20,9 +20,9 @@ final class AddAdditionalFieldsToPeople extends AbstractMigration
     public function change(): void
     {
         $this->table('people')
-            ->addColumn('customfield1_value', 'string', ['default' => '', 'null' => false])
-            ->addColumn('customfield2_value', 'string', ['default' => '', 'null' => false])
-            ->addColumn('customfield3_value', 'string', ['default' => '', 'null' => false])
+            ->addColumn('customfield1_value', 'string', ['default' => null, 'null' => true])
+            ->addColumn('customfield2_value', 'string', ['default' => null, 'null' => true])
+            ->addColumn('customfield3_value', 'string', ['default' => null, 'null' => true])
             ->addColumn('customfield4_value', 'datetime', ['default' => null, 'null' => true])
             ->save()
         ;

--- a/db/migrations/20250328141120_add_additional_settings_for_bases.php
+++ b/db/migrations/20250328141120_add_additional_settings_for_bases.php
@@ -26,10 +26,10 @@ final class AddAdditionalSettingsForBases extends AbstractMigration
             ->addColumn('additional_field2_enabled', 'boolean', ['default' => 0, 'null' => false])
             ->addColumn('additional_field3_enabled', 'boolean', ['default' => 0, 'null' => false])
             ->addColumn('additional_field4_enabled', 'boolean', ['default' => 0, 'null' => false])
-            ->addColumn('additional_field1_label', 'string', ['default' => '', 'null' => false])
-            ->addColumn('additional_field2_label', 'string', ['default' => '', 'null' => false])
-            ->addColumn('additional_field3_label', 'string', ['default' => '', 'null' => false])
-            ->addColumn('additional_field4_label', 'string', ['default' => '', 'null' => false])
+            ->addColumn('additional_field1_label', 'string', ['default' => null, 'null' => true])
+            ->addColumn('additional_field2_label', 'string', ['default' => null, 'null' => true])
+            ->addColumn('additional_field3_label', 'string', ['default' => null, 'null' => true])
+            ->addColumn('additional_field4_label', 'string', ['default' => null, 'null' => true])
             ->save()
         ;
     }

--- a/db/migrations/20250328141120_add_additional_settings_for_bases.php
+++ b/db/migrations/20250328141120_add_additional_settings_for_bases.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddAdditionalSettingsForBases extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change(): void
+    {
+        $this->table('camps')
+            ->addColumn('email_enabled', 'boolean', ['default' => 0, 'null' => false])
+            ->addColumn('phone_enabled', 'boolean', ['default' => 0, 'null' => false])
+            ->addColumn('additional_field1_enabled', 'boolean', ['default' => 0, 'null' => false])
+            ->addColumn('additional_field2_enabled', 'boolean', ['default' => 0, 'null' => false])
+            ->addColumn('additional_field3_enabled', 'boolean', ['default' => 0, 'null' => false])
+            ->addColumn('additional_field4_enabled', 'boolean', ['default' => 0, 'null' => false])
+            ->addColumn('additional_field1_label', 'string', ['default' => '', 'null' => false])
+            ->addColumn('additional_field2_label', 'string', ['default' => '', 'null' => false])
+            ->addColumn('additional_field3_label', 'string', ['default' => '', 'null' => false])
+            ->addColumn('additional_field4_label', 'string', ['default' => '', 'null' => false])
+            ->save()
+        ;
+    }
+}

--- a/db/migrations/20250415134236_add_base_setting_menu.php
+++ b/db/migrations/20250415134236_add_base_setting_menu.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddBaseSettingMenu extends AbstractMigration
+{
+    public function up(): void
+    {
+        $dbName = $this->fetchRow('SELECT DATABASE();');
+        $this->output->writeln("Running upwards migration on database: {$dbName[0]}");
+
+        // add new menu items
+        $this->execute("
+            INSERT INTO `cms_functions` (`id`, `parent_id`, `title_en`, `include`, `seq`, `alert`, `adminonly`, `visible`, `allusers`, `allcamps`, `action_permissions`) VALUES ('170', '42', 'Base Settings (<span>beta</span>)', 'base_settings', '28', '0', '0', '1', '0', '1', 'manage_base_settings');
+        ");
+
+        // enable everywhere except in production
+        if ('dropapp_production' != $dbName[0]) {
+            // cms_usergroups_functions for Manage Services
+            $this->execute("
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '1');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '2');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '10');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '11');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '12');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '15');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '17');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '100000001');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '100000002');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '100000206');
+                INSERT INTO `cms_usergroups_functions` (`cms_functions_id`, `cms_usergroups_id`) VALUES ('170', '100000207');
+            ");
+        } else {
+            $this->output->writeln('Only cms_functions is touched since we are in dropapp_production');
+        }
+    }
+
+    public function down(): void
+    {
+        $dbName = $this->fetchRow('SELECT DATABASE();');
+        $this->output->writeln("Running downwards migration on database: {$dbName[0]}");
+        if ('dropapp_production' != $dbName[0]) {
+            $this->execute("
+                DELETE FROM `cms_functions_camps` WHERE `cms_functions_id` = '170';
+            ");
+        } else {
+            $this->output->writeln('Only cms_functions is touched since we are in dropapp_production');
+        }
+
+        $this->execute("
+            DELETE FROM `cms_functions` WHERE `id` = '170';
+        ");
+    }
+}

--- a/include/base_settings.php
+++ b/include/base_settings.php
@@ -3,8 +3,8 @@
 $table = 'camps';
 $action = 'base_settings';
 
-if ($_POST && authorize('manage_base_settings',4)) {
-    db_transaction(function () use ($table, $rolesToActions, $menusToActions) {
+if ($_POST && authorize('manage_base_settings', 4)) {
+    db_transaction(function () use ($table) {
         $_POST['id'] = $_SESSION['camp']['id'];
         $handler = new formHandler($table);
 
@@ -23,7 +23,7 @@ if ($_POST && authorize('manage_base_settings',4)) {
             'additional_field3_label',
             'additional_field4_label',
             'delete_inactive_users',
-            'daystokeepdeletedpersons',            
+            'daystokeepdeletedpersons',
             'adult_age',
             'currencyname',
             'dropsperadult',
@@ -114,16 +114,15 @@ addfield('text', 'Label', 'additional_field4_label', [
     'tooltip' => 'Provide a label for the date field (e.g., "Next Visit Date").',
 ]);
 
-
 addfield('number', 'Days to deactivate inactive beneficiaries', 'delete_inactive_users', ['tab' => 'market', 'width' => 2, 'tooltip' => 'Beneficiaries without activity in Boxtribute will be deactivated. Deactivated beneficiaries will remain visible in the Deactivated tab in the Beneficiaries page.']);
 addfield('number', 'Days to keep deactivated beneficiaries', 'daystokeepdeletedpersons', ['tab' => 'market', 'width' => 2, 'tooltip' => 'Deactivate beneficiaries will remain visible in the Deactivated tab in the beneficiaries page and will be completely deleted after a while. Here you can define how long they will remain in the Deactivated list.']);
 addfield('number', 'Adult age', 'adult_age', ['tab' => 'market', 'width' => 2, 'tooltip' => 'For some functions we distinct between children and adults. Fill in here the lowest age considered adult for this base.']);
 addfield('text', 'Currency name', 'currencyname', ['tab' => 'market', 'required' => true, 'width' => 2, 'tooltip' => 'Will get active after first page reload']);
 addfield('line', '', '', ['tab' => 'market']);
-addfield('title', 'Default '. $_SESSION['camp']['currencyname'].' per cycle', '', ['tab' => 'market']);
+addfield('title', 'Default '.$_SESSION['camp']['currencyname'].' per cycle', '', ['tab' => 'market']);
 addfield('number', $_SESSION['camp']['currencyname'].' per adult', 'dropsperadult', ['tab' => 'market', 'width' => 2]);
 addfield('number', $_SESSION['camp']['currencyname'].' per child', 'dropsperchild', ['tab' => 'market', 'width' => 2]);
-addfield('checkbox', 'Reset tokens on cycle restart', 'resettokens', ['tab' => 'market', 'tooltip'=>'If you distribute tokens to a person, first all tokens of the beneficiary are reset to 0 before new ones are distributed.']);
+addfield('checkbox', 'Reset tokens on cycle restart', 'resettokens', ['tab' => 'market', 'tooltip' => 'If you distribute tokens to a person, first all tokens of the beneficiary are reset to 0 before new ones are distributed.']);
 
 // place the form elements and data in the template
 $cmsmain->assign('data', $data);

--- a/include/base_settings.php
+++ b/include/base_settings.php
@@ -1,0 +1,131 @@
+<?php
+
+$table = 'camps';
+$action = 'base_settings';
+
+if ($_POST && authorize('manage_base_settings',4)) {
+    db_transaction(function () use ($table, $rolesToActions, $menusToActions) {
+        $_POST['id'] = $_SESSION['camp']['id'];
+        $handler = new formHandler($table);
+
+        $savekeys = [
+            'familyidentifier',
+            'beneficiaryisregistered',
+            'beneficiaryisvolunteer',
+            'email_enabled',
+            'phone_enabled',
+            'additional_field1_enabled',
+            'additional_field2_enabled',
+            'additional_field3_enabled',
+            'additional_field4_enabled',
+            'additional_field1_label',
+            'additional_field2_label',
+            'additional_field3_label',
+            'additional_field4_label',
+            'delete_inactive_users',
+            'daystokeepdeletedpersons',            
+            'adult_age',
+            'currencyname',
+            'dropsperadult',
+            'dropsperchild',
+            'resettokens',
+        ];
+        $id = $handler->savePost($savekeys);
+
+        $_SESSION['camp'] = getcampdata($_SESSION['camp']['id']);
+    });
+
+    redirect('?action=start');
+}
+
+$data = db_row('SELECT * FROM camps WHERE id = :id', ['id' => $_SESSION['camp']['id']]);
+
+// open the template
+$cmsmain->assign('include', 'cms_form.tpl');
+
+// put a title above the form
+$cmsmain->assign('title', 'Base Settings');
+
+$tabs['beneficiaries'] = 'Beneficiaries';
+$tabs['market'] = 'Free Shop';
+$cmsmain->assign('tabs', $tabs);
+
+// Beneficiaries
+addfield('text', 'Name of beneficiary identifier', 'familyidentifier', ['tab' => 'beneficiaries', 'tooltip' => 'Each beneficiary or family has usually an id or address like an ID from camp mgmt. or the number of the container they live in. How should we name it?']);
+addfield('checkbox', 'Do you track if your beneficiaries are officially registered?', 'beneficiaryisregistered', ['tab' => 'beneficiaries']);
+addfield('checkbox', 'Can your beneficiaries be volunteers in your organisation?', 'beneficiaryisvolunteer', ['tab' => 'beneficiaries']);
+addfield('checkbox', 'Record email for beneficiaries?', 'email_enabled', [
+    'tab' => 'beneficiaries',
+    'tooltip' => 'Allow users to enter an email address for the beneficiary. This field is optional and can be used for communication purposes.',
+]);
+addfield('checkbox', 'Record phone number for beneficiaries?', 'phone_enabled', [
+    'tab' => 'beneficiaries',
+    'tooltip' => 'Allow users to enter a phone number for the beneficiary. This field is optional and can be used for direct communication.',
+]);
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+addfield('subtitle', 'Custom Text Field 1', '', ['tab' => 'beneficiaries', 'tooltip' => 'If the checkbox is enabled, a text field will be added to the beneficiary form with the provided label.']);
+addfield('checkbox', 'Enable Field?', 'additional_field1_enabled', [
+    'tab' => 'beneficiaries',
+    'size' => 2,
+    'onchange' => 'conditionalToggle("additional_field1_enabled", "additional_field1_label")',
+]);
+addfield('text', 'Label', 'additional_field1_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field1_enabled'] ? false : true,
+    'required' => $data['additional_field1_enabled'],
+    'tooltip' => 'Provide a label for this field (e.g., "Family Size" or "Occupation").',
+]);
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+addfield('subtitle', 'Custom Text Field 2', '', ['tab' => 'beneficiaries', 'tooltip' => 'If the checkbox is enabled, a text field will be added to the beneficiary form with the provided label.']);
+addfield('checkbox', 'Enable Field?', 'additional_field2_enabled', [
+    'tab' => 'beneficiaries',
+    'onchange' => 'conditionalToggle("additional_field2_enabled", "additional_field2_label")',
+    'checked' => $data['additional_field2_enabled'],
+]);
+addfield('text', 'Label', 'additional_field2_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field2_enabled'] ? false : true,
+    'required' => $data['additional_field2_enabled'],
+    'tooltip' => 'Provide a label for the second custom field (e.g., "Living Area" or "Notes").',
+]);
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+addfield('subtitle', 'Custom Number Field', '', ['tab' => 'beneficiaries', 'tooltip' => 'If the checkbox is enabled, a number field will be added to the beneficiary form with the provided label.']);
+addfield('checkbox', 'Enable Field?', 'additional_field3_enabled', [
+    'tab' => 'beneficiaries',
+    'onchange' => 'conditionalToggle("additional_field3_enabled", "additional_field3_label")',
+]);
+addfield('text', 'Label', 'additional_field3_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field3_enabled'] ? false : true,
+    'required' => $data['additional_field3_enabled'],
+    'tooltip' => 'Provide a label for the number field (e.g., "Number of Family Members").',
+]);
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+addfield('subtitle', 'Custom Date Field', '', ['tab' => 'beneficiaries', 'tooltip' => 'If the checkbox is enabled, a date field will be added to the beneficiary form with the provided label.']);
+addfield('checkbox', 'Enable Field?', 'additional_field4_enabled', [
+    'tab' => 'beneficiaries',
+    'onchange' => 'conditionalToggle("additional_field4_enabled", "additional_field4_label")',
+]);
+
+addfield('text', 'Label', 'additional_field4_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field4_enabled'] ? false : true,
+    'required' => $data['additional_field4_enabled'],
+    'tooltip' => 'Provide a label for the date field (e.g., "Next Visit Date").',
+]);
+
+
+addfield('number', 'Days to deactivate inactive beneficiaries', 'delete_inactive_users', ['tab' => 'market', 'width' => 2, 'tooltip' => 'Beneficiaries without activity in Boxtribute will be deactivated. Deactivated beneficiaries will remain visible in the Deactivated tab in the Beneficiaries page.']);
+addfield('number', 'Days to keep deactivated beneficiaries', 'daystokeepdeletedpersons', ['tab' => 'market', 'width' => 2, 'tooltip' => 'Deactivate beneficiaries will remain visible in the Deactivated tab in the beneficiaries page and will be completely deleted after a while. Here you can define how long they will remain in the Deactivated list.']);
+addfield('number', 'Adult age', 'adult_age', ['tab' => 'market', 'width' => 2, 'tooltip' => 'For some functions we distinct between children and adults. Fill in here the lowest age considered adult for this base.']);
+addfield('text', 'Currency name', 'currencyname', ['tab' => 'market', 'required' => true, 'width' => 2, 'tooltip' => 'Will get active after first page reload']);
+addfield('line', '', '', ['tab' => 'market']);
+addfield('title', 'Default '. $_SESSION['camp']['currencyname'].' per cycle', '', ['tab' => 'market']);
+addfield('number', $_SESSION['camp']['currencyname'].' per adult', 'dropsperadult', ['tab' => 'market', 'width' => 2]);
+addfield('number', $_SESSION['camp']['currencyname'].' per child', 'dropsperchild', ['tab' => 'market', 'width' => 2]);
+addfield('checkbox', 'Reset tokens on cycle restart', 'resettokens', ['tab' => 'market', 'tooltip'=>'If you distribute tokens to a person, first all tokens of the beneficiary are reset to 0 before new ones are distributed.']);
+
+// place the form elements and data in the template
+$cmsmain->assign('data', $data);
+$cmsmain->assign('formelements', $formdata);
+$cmsmain->assign('formbuttons', $formbuttons);

--- a/include/camps_edit.php
+++ b/include/camps_edit.php
@@ -9,7 +9,50 @@ if ($_POST) {
         $baseName = trim((string) $_POST['name']);
         $baseIsNew = !(!empty($_POST['id']) && preg_match('/\d+/', (string) $_POST['id']));
 
-        $savekeys = ['name', 'market', 'familyidentifier', 'delete_inactive_users', 'food', 'bicycle', 'idcard', 'workshop', 'laundry', 'schedulestart', 'schedulestop', 'schedulebreak', 'schedulebreakstart', 'schedulebreakduration', 'scheduletimeslot', 'currencyname', 'dropsperadult', 'dropsperchild', 'dropcapadult', 'dropcapchild', 'bicyclerenttime', 'adult_age', 'daystokeepdeletedpersons', 'extraportion', 'maxfooddrops_adult', 'maxfooddrops_child', 'bicycle_closingtime', 'bicycle_closingtime_saturday', 'organisation_id', 'resettokens', 'beneficiaryisregistered', 'beneficiaryisvolunteer'];
+        $savekeys = [
+            'name',
+            'market',
+            'familyidentifier',
+            'delete_inactive_users',
+            'food',
+            'bicycle',
+            'idcard',
+            'workshop',
+            'laundry',
+            'schedulestart',
+            'schedulestop',
+            'schedulebreak',
+            'schedulebreakstart',
+            'schedulebreakduration',
+            'scheduletimeslot',
+            'currencyname',
+            'dropsperadult',
+            'dropsperchild',
+            'dropcapadult',
+            'dropcapchild',
+            'bicyclerenttime',
+            'adult_age',
+            'daystokeepdeletedpersons',
+            'extraportion',
+            'maxfooddrops_adult',
+            'maxfooddrops_child',
+            'bicycle_closingtime',
+            'bicycle_closingtime_saturday',
+            'organisation_id',
+            'resettokens',
+            'beneficiaryisregistered',
+            'beneficiaryisvolunteer',
+            'email_enabled',
+            'phone_enabled',
+            'additional_field1_enabled',
+            'additional_field2_enabled',
+            'additional_field3_enabled',
+            'additional_field4_enabled',
+            'additional_field1_label',
+            'additional_field2_label',
+            'additional_field3_label',
+            'additional_field4_label',
+        ];
         $id = $handler->savePost($savekeys);
         // $handler->saveMultiple('functions', 'cms_functions_camps', 'camps_id', 'cms_functions_id');
         if ($baseIsNew) {
@@ -77,6 +120,80 @@ addfield('text', 'Location identifier for beneficiaries', 'familyidentifier', ['
 addfield('checkbox', 'Do you give out beneficiaries ID-cards?', 'idcard', ['tab' => 'beneficiaries']);
 addfield('checkbox', 'Do you track if your beneficiaries are officially registered?', 'beneficiaryisregistered', ['tab' => 'beneficiaries']);
 addfield('checkbox', 'Can your beneficiaries be volunteers in your organisation?', 'beneficiaryisvolunteer', ['tab' => 'beneficiaries']);
+
+// Add options to choose to enable email and/or phone fields, and to define custom fields for the beneficiary form
+// Trello Ref. https://trello.com/c/WmBmSHyp
+addfield('checkbox', 'Enable email field for beneficiaries?', 'email_enabled', [
+    'tab' => 'beneficiaries',
+    'tooltip' => 'Allow users to enter an email address for the beneficiary. This field is optional and can be used for communication purposes.',
+]);
+
+addfield('checkbox', 'Enable phone number field for beneficiaries?', 'phone_enabled', [
+    'tab' => 'beneficiaries',
+    'tooltip' => 'Allow users to enter a phone number for the beneficiary. This field is optional and can be used for direct communication.',
+]);
+
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+
+addfield('title', 'Enable Additional Custom Fields', '', ['tab' => 'beneficiaries', 'tooltip' => 'If the checkbox is enabled, a text field will be added to the beneficiary form with the provided label.']);
+
+// Custom Text Field 1 (Free Text)
+addfield('checkbox', 'Enable text field 1 (e.g., Family Size)', 'additional_field1_enabled', [
+    'tab' => 'beneficiaries',
+    'size' => 2,
+    'onchange' => 'conditionalToggle("additional_field1_enabled", "additional_field1_label")',
+]);
+
+addfield('text', 'Text field 1 label', 'additional_field1_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field1_enabled'] ? false : true,
+    'required' => $data['additional_field1_enabled'],
+    'tooltip' => 'Provide a label for this field (e.g., "Family Size" or "Occupation").',
+]);
+
+// Custom Text Field 2 (Free Text)
+addfield('checkbox', 'Enable text field 2 (e.g., Living Area)', 'additional_field2_enabled', [
+    'tab' => 'beneficiaries',
+    'onchange' => 'conditionalToggle("additional_field2_enabled", "additional_field2_label")',
+    'checked' => $data['additional_field2_enabled'],
+]);
+
+addfield('text', 'Text field 2 label', 'additional_field2_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field2_enabled'] ? false : true,
+    'required' => $data['additional_field2_enabled'],
+    'tooltip' => 'Provide a label for the second custom field (e.g., "Living Area" or "Notes").',
+]);
+
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+
+// Custom Number Field (e.g., Number of Family Members)
+addfield('checkbox', 'Enable number field (e.g., Family Members)', 'additional_field3_enabled', [
+    'tab' => 'beneficiaries',
+    'onchange' => 'conditionalToggle("additional_field3_enabled", "additional_field3_label")',
+]);
+
+addfield('text', 'Number field label', 'additional_field3_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field3_enabled'] ? false : true,
+    'required' => $data['additional_field3_enabled'],
+    'tooltip' => 'Provide a label for the number field (e.g., "Number of Family Members").',
+]);
+
+addfield('line', '', '', ['tab' => 'beneficiaries']);
+
+// Custom Date Field (e.g., Next Visit Date)
+addfield('checkbox', 'Enable date field (e.g., Next Visit Date)', 'additional_field4_enabled', [
+    'tab' => 'beneficiaries',
+    'onchange' => 'conditionalToggle("additional_field4_enabled", "additional_field4_label")',
+]);
+
+addfield('text', 'Date field label', 'additional_field4_label', [
+    'tab' => 'beneficiaries',
+    'disabled' => $data['additional_field4_enabled'] ? false : true,
+    'required' => $data['additional_field4_enabled'],
+    'tooltip' => 'Provide a label for the date field (e.g., "Next Visit Date").',
+]);
 
 addfield('text', 'Currency name', 'currencyname', ['tab' => 'market', 'required' => true, 'width' => 2, 'tooltip' => 'Will get active after first page reload']);
 addfield('line', '', '', ['tab' => 'market']);

--- a/include/people_deactivated.php
+++ b/include/people_deactivated.php
@@ -21,7 +21,21 @@ if (!$ajax) {
     listsetting('allowdelete', false);
     listsetting('allowedit', false);
     // listsetting('allowselect',array(1));
-    listsetting('search', ['firstname', 'lastname', 'container']);
+    $search_fields = ['firstname', 'lastname', 'container'];
+    // Add search fields for the additional custom fields if enabled
+    if ($_SESSION['camp']['email_enabled']) {
+        $search_fields[] = 'email';
+    }
+    if ($_SESSION['camp']['phone_enabled']) {
+        $search_fields[] = 'phone';
+    }
+    if ($_SESSION['camp']['additional_field1_enabled']) {
+        $search_fields[] = 'customfield1_value';
+    }
+    if ($_SESSION['camp']['additional_field2_enabled']) {
+        $search_fields[] = 'customfield2_value';
+    }
+    listsetting('search', $search_fields);
     listsetting('allowadd', false);
     listsetting('haspagemenu', true);
 
@@ -61,6 +75,25 @@ if (!$ajax) {
     addcolumn('text', $_SESSION['camp']['familyidentifier'], 'container');
     addcolumn('text', ucwords((string) $_SESSION['camp']['currencyname']), 'drops');
     addcolumn('datetime', 'Last active', 'lastactive');
+    // Display additional custom fields if enabled
+    if ($_SESSION['camp']['email_enabled']) {
+        addcolumn('text', 'Email address', 'email');
+    }
+    if ($_SESSION['camp']['phone_enabled']) {
+        addcolumn('text', 'Phone number', 'phone');
+    }
+    if ($_SESSION['camp']['additional_field1_enabled']) {
+        addcolumn('text', $_SESSION['camp']['additional_field1_label'], 'customfield1_value');
+    }
+    if ($_SESSION['camp']['additional_field2_enabled']) {
+        addcolumn('text', $_SESSION['camp']['additional_field2_label'], 'customfield2_value');
+    }
+    if ($_SESSION['camp']['additional_field3_enabled']) {
+        addcolumn('text', $_SESSION['camp']['additional_field3_label'], 'customfield3_value');
+    }
+    if ($_SESSION['camp']['additional_field4_enabled']) {
+        addcolumn('date', $_SESSION['camp']['additional_field4_label'], 'customfield4_value');
+    }
 
     addbutton('undelete', 'Activate', ['icon' => 'fa-history', 'oneitemonly' => false, 'testId' => 'recoverDeactivatedUser']);
     addbutton('realdelete', 'Full delete', ['icon' => 'fa-trash', 'oneitemonly' => false, 'confirm' => true, 'testId' => 'fullDeleteUser']);

--- a/include/people_edit.php
+++ b/include/people_edit.php
@@ -132,6 +132,18 @@ if ($_POST) {
             $savekeys[] = 'laundryblock';
             $savekeys[] = 'laundrycomment';
         }
+        if ($_SESSION['camp']['additional_field1_enabled']) {
+            $savekeys[] = 'customfield1_value';
+        }
+        if ($_SESSION['camp']['additional_field2_enabled']) {
+            $savekeys[] = 'customfield2_value';
+        }
+        if ($_SESSION['camp']['additional_field3_enabled']) {
+            $savekeys[] = 'customfield3_value';
+        }
+        if ($_SESSION['camp']['additional_field4_enabled']) {
+            $savekeys[] = 'customfield4_value';
+        }
         $id = $handler->savePost($savekeys, ['parent_id']);
 
         // edit tags
@@ -344,6 +356,24 @@ addfield('select', 'Gender', 'gender', ['testid' => 'gender_id', 'tab' => 'peopl
     'options' => [['value' => 'M', 'label' => 'Male'], ['value' => 'F', 'label' => 'Female']], ]);
 addfield('date', 'Date of birth', 'date_of_birth', ['testid' => 'date_of_birth_id', 'tab' => 'people', 'date' => true, 'time' => false]);
 addfield('line', '', '', ['tab' => 'people']);
+if ($_SESSION['camp']['email_enabled']) {
+    addfield('text', 'Email address', 'email', ['tab' => 'people']);
+}
+if ($_SESSION['camp']['phone_enabled']) {
+    addfield('text', 'Phone number', 'phone', ['tab' => 'people']);
+}
+if ($_SESSION['camp']['additional_field1_enabled']) {
+    addfield('text', $_SESSION['camp']['additional_field1_label'], 'customfield1_value', ['tab' => 'people']);
+}
+if ($_SESSION['camp']['additional_field2_enabled']) {
+    addfield('text', $_SESSION['camp']['additional_field2_label'], 'customfield2_value', ['tab' => 'people']);
+}
+if ($_SESSION['camp']['additional_field3_enabled']) {
+    addfield('number', $_SESSION['camp']['additional_field3_label'], 'customfield3_value', ['tab' => 'people', 'size' => 2]);
+}
+if ($_SESSION['camp']['additional_field4_enabled']) {
+    addfield('date', $_SESSION['camp']['additional_field4_label'], 'customfield4_value', ['tab' => 'people', 'time' => false, 'date' => true]);
+}
 addfield('select', 'Tag(s)', 'tags', ['testid' => 'tag_id', 'tab' => 'people', 'multiple' => true, 'query' => 'SELECT tags.id AS value, tags.label, IF(tags_relations.object_id IS NOT NULL, 1,0) AS selected FROM tags LEFT JOIN tags_relations ON tags.id = tags_relations.tag_id AND tags_relations.object_id = '.intval($id).' AND tags_relations.object_type = "People" AND tags_relations.deleted_on IS NULL WHERE tags.camp_id = '.$_SESSION['camp']['id'].' AND tags.deleted IS NULL AND tags.type IN ("All","People") ORDER BY seq']);
 addfield('select', 'Language(s)', 'languages', ['testid' => 'language_id', 'tab' => 'people', 'multiple' => true, 'query' => 'SELECT a.id AS value, a.name AS label, IF(x.people_id IS NOT NULL, 1,0) AS selected FROM languages AS a LEFT OUTER JOIN x_people_languages AS x ON a.id = x.language_id AND x.people_id = '.intval($id).' WHERE a.visible']);
 addfield('textarea', 'Comments', 'comments', ['testid' => 'comments_id', 'tab' => 'people']);
@@ -441,9 +471,9 @@ if (0 == $data['parent_id']) {
                 'redirect' => true,
                 'allowsort' => false,
                 'modal' => false,
-                'button' => (count($datalastpurchases) == $limitlastpurchases ?
-                    ['showallpurchases&people_id='.$id => ['label' => 'Show all', 'showalways' => true]] :
-                    []),
+                'button' => (count($datalastpurchases) == $limitlastpurchases
+                    ? ['showallpurchases&people_id='.$id => ['label' => 'Show all', 'showalways' => true]]
+                    : []),
             ]
         );
         addfield('ajaxend', '', '', ['tab' => 'transaction']);
@@ -483,9 +513,9 @@ if (0 == $data['parent_id']) {
                 'action' => 'people_edit',
                 'redirect' => true,
                 'modal' => false,
-                'button' => (count($datalasttransactions) == $limitlasttransactions ?
-                    ['showalltransactions&people_id='.$id => ['label' => 'Show all', 'showalways' => true]] :
-                    []),
+                'button' => (count($datalasttransactions) == $limitlasttransactions
+                    ? ['showalltransactions&people_id='.$id => ['label' => 'Show all', 'showalways' => true]]
+                    : []),
             ]
         );
         addfield('ajaxend', '', '', ['tab' => 'transaction']);

--- a/include/people_edit.php
+++ b/include/people_edit.php
@@ -186,7 +186,7 @@ if ($_POST) {
         $handler->saveMultiple('languages', 'x_people_languages', 'people_id', 'language_id');
 
         $postid = ($_POST['id'] ?: $id);
-        if (is_uploaded_file($_FILES['picture']['tmp_name'])) {
+        if (isset($_FILES['picture']) && !empty($_FILES['picture']['tmp_name']) && is_uploaded_file($_FILES['picture']['tmp_name'])) {
             if ('image/jpeg' == $_FILES['picture']['type']) {
                 $targetFile = $settings['upload_dir'].'/people/'.$postid.'.jpg';
                 $res = move_uploaded_file($_FILES['picture']['tmp_name'], $targetFile);

--- a/include/people_edit.php
+++ b/include/people_edit.php
@@ -146,6 +146,12 @@ if ($_POST) {
         }
         $id = $handler->savePost($savekeys, ['parent_id']);
 
+        // Validate if E-mail address is correct
+        if (!empty($_POST['email']) && !checkEmail($_POST['email'])) {
+            redirect('?action=people_edit&id='.$id.'&origin='.$_POST['_origin'].'&warning=1&message=This beneficiary email is not valid');
+            trigger_error('This beneficiary email is not valid', E_USER_NOTICE);
+        }
+
         // edit tags
         $now = (new DateTime())->format('Y-m-d H:i:s');
         $user_id = $_SESSION['user']['id'];
@@ -357,7 +363,7 @@ addfield('select', 'Gender', 'gender', ['testid' => 'gender_id', 'tab' => 'peopl
 addfield('date', 'Date of birth', 'date_of_birth', ['testid' => 'date_of_birth_id', 'tab' => 'people', 'date' => true, 'time' => false]);
 addfield('line', '', '', ['tab' => 'people']);
 if ($_SESSION['camp']['email_enabled']) {
-    addfield('text', 'Email address', 'email', ['tab' => 'people']);
+    addfield('email', 'Email address', 'email', ['tab' => 'people']);
 }
 if ($_SESSION['camp']['phone_enabled']) {
     addfield('text', 'Phone number', 'phone', ['tab' => 'people']);

--- a/include/people_edit.php
+++ b/include/people_edit.php
@@ -362,6 +362,12 @@ addfield('select', 'Gender', 'gender', ['testid' => 'gender_id', 'tab' => 'peopl
     'options' => [['value' => 'M', 'label' => 'Male'], ['value' => 'F', 'label' => 'Female']], ]);
 addfield('date', 'Date of birth', 'date_of_birth', ['testid' => 'date_of_birth_id', 'tab' => 'people', 'date' => true, 'time' => false]);
 addfield('line', '', '', ['tab' => 'people']);
+addfield('select', 'Tag(s)', 'tags', ['testid' => 'tag_id', 'tab' => 'people', 'multiple' => true, 'query' => 'SELECT tags.id AS value, tags.label, IF(tags_relations.object_id IS NOT NULL, 1,0) AS selected FROM tags LEFT JOIN tags_relations ON tags.id = tags_relations.tag_id AND tags_relations.object_id = '.intval($id).' AND tags_relations.object_type = "People" AND tags_relations.deleted_on IS NULL WHERE tags.camp_id = '.$_SESSION['camp']['id'].' AND tags.deleted IS NULL AND tags.type IN ("All","People") ORDER BY seq']);
+addfield('select', 'Language(s)', 'languages', ['testid' => 'language_id', 'tab' => 'people', 'multiple' => true, 'query' => 'SELECT a.id AS value, a.name AS label, IF(x.people_id IS NOT NULL, 1,0) AS selected FROM languages AS a LEFT OUTER JOIN x_people_languages AS x ON a.id = x.language_id AND x.people_id = '.intval($id).' WHERE a.visible']);
+addfield('textarea', 'Comments', 'comments', ['testid' => 'comments_id', 'tab' => 'people']);
+addfield('line', '', '', ['tab' => 'people']);
+
+// custom fields
 if ($_SESSION['camp']['email_enabled']) {
     addfield('email', 'Email address', 'email', ['tab' => 'people']);
 }
@@ -380,10 +386,6 @@ if ($_SESSION['camp']['additional_field3_enabled']) {
 if ($_SESSION['camp']['additional_field4_enabled']) {
     addfield('date', $_SESSION['camp']['additional_field4_label'], 'customfield4_value', ['tab' => 'people', 'time' => false, 'date' => true]);
 }
-addfield('select', 'Tag(s)', 'tags', ['testid' => 'tag_id', 'tab' => 'people', 'multiple' => true, 'query' => 'SELECT tags.id AS value, tags.label, IF(tags_relations.object_id IS NOT NULL, 1,0) AS selected FROM tags LEFT JOIN tags_relations ON tags.id = tags_relations.tag_id AND tags_relations.object_id = '.intval($id).' AND tags_relations.object_type = "People" AND tags_relations.deleted_on IS NULL WHERE tags.camp_id = '.$_SESSION['camp']['id'].' AND tags.deleted IS NULL AND tags.type IN ("All","People") ORDER BY seq']);
-addfield('select', 'Language(s)', 'languages', ['testid' => 'language_id', 'tab' => 'people', 'multiple' => true, 'query' => 'SELECT a.id AS value, a.name AS label, IF(x.people_id IS NOT NULL, 1,0) AS selected FROM languages AS a LEFT OUTER JOIN x_people_languages AS x ON a.id = x.language_id AND x.people_id = '.intval($id).' WHERE a.visible']);
-addfield('textarea', 'Comments', 'comments', ['testid' => 'comments_id', 'tab' => 'people']);
-addfield('line', '', '', ['tab' => 'people']);
 if ($_SESSION['camp']['beneficiaryisregistered']) {
     addfield('checkbox', 'This person is not officially registered.', 'notregistered', ['testid' => 'registered_id', 'tab' => 'people']);
 }

--- a/include/people_export.php
+++ b/include/people_export.php
@@ -52,4 +52,24 @@ $keys = [
     'familyhead' => 'Head of Family',
 ];
 
+// Add custom fields if they are enabled
+if ($_SESSION['camp']['email_enabled']) {
+    $keys['email'] = 'Email';
+}
+if ($_SESSION['camp']['phone_enabled']) {
+    $keys['phone'] = 'Phone';
+}
+if ($_SESSION['camp']['additional_field1_enabled']) {
+    $keys['customfield1_value'] = trim($_SESSION['camp']['additional_field1_label']);
+}
+if ($_SESSION['camp']['additional_field2_enabled']) {
+    $keys['customfield2_value'] = trim($_SESSION['camp']['additional_field2_label']);
+}
+if ($_SESSION['camp']['additional_field3_enabled']) {
+    $keys['customfield3_value'] = trim($_SESSION['camp']['additional_field3_label']);
+}
+if ($_SESSION['camp']['additional_field4_enabled']) {
+    $keys['customfield4_value'] = trim($_SESSION['camp']['additional_field4_label']);
+}
+
 csvexport($result, 'Beneficiaries_'.$_SESSION['camp']['name'], $keys);

--- a/templates/cms_footer.tpl
+++ b/templates/cms_footer.tpl
@@ -7,7 +7,7 @@
     <script src="/assets/jsignature/jquery.signature.js"></script>
 
     <script src="/assets/js/magic.js?v=14"></script>
-    <script src="/assets/js/custom.js?v=12"></script> 
+    <script src="/assets/js/custom.js?v=13"></script> 
     <script src="/assets/js/shoppingCart.js"></script>    
 
 	  {if $smarty.session.user}

--- a/templates/cms_form_subtitle.tpl
+++ b/templates/cms_form_subtitle.tpl
@@ -1,0 +1,8 @@
+	<div class="form-group">
+		{if $element['indented']}<div class="col-sm-2"></div>{/if}
+		{if not isset($element['labelindent'])}<label for="field_{$element['field']}" class="control-label col-sm-2">&nbsp;</label>{/if}
+		<div class="col-sm-{if $element['width']>0 and $element['width']<11}{$element['width']}{else}6{/if}">
+	 		<h3 {if isset($element['id'])} id={$element["id"]}{/if}>{$element['label']}</h3>
+			{if $element['tooltip']}{include file="cms_tooltip.tpl"}{/if}
+		</div>
+	</div>

--- a/templates/cms_form_text.tpl
+++ b/templates/cms_form_text.tpl
@@ -16,6 +16,7 @@
 	 			onblur="{$element['onblur']};" 
 				{if $element['minlength']}minlength="{$element['minlength']}"{/if}
 				{if $element['readonly'] || $element['locked']}readonly{/if} 
+				{if $element['disabled']}disabled{/if} 
 				{if $element['required']}required{/if}
 				{if isset($element['testid'])}data-testid="{$element['testid']}"{/if}
 			>


### PR DESCRIPTION
This PR introduces the addition of flexible custom fields in the beneficiary form, along with the ability to enable email and/or phone number fields. It also ensures that the new fields are included in the export functionality if enabled in the base settings. As part of this update, migrations are added for the new fields in both the `people` and `camps` tables, and the previously defined `phone` and `email` fields in the `people` table are now utilized.